### PR TITLE
add support for marshaling and unmarshaling the LIFX LAN message header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+go:
+  - 1.5.3
+script: go test -v ./... -check.vv
+sudo: false
+notifications:
+  email:
+    on_success: never
+    on_failure: never

--- a/protocol/frame.go
+++ b/protocol/frame.go
@@ -1,0 +1,147 @@
+package lifxprotocol
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// MaxFrameOrigin is the max size of the Frame.Origin field.
+// It only uses the top 2 bits so its maximum value is 3
+const MaxFrameOrigin = ^uint8(0) >> 6
+
+// MaxFrameProtocol is the max size of the The Frame.Protocol field.
+// It only uses the top 12 bits so its maximum value is 4095.
+const MaxFrameProtocol = ^uint16(0) >> 4
+
+// FrameByteSize is the number of bytes in a marshaled Frame struct
+const FrameByteSize int = 8
+
+// ErrFrameProtocolOverflow is the error returned when the Frame.Protocol value is too large
+var ErrFrameProtocolOverflow = fmt.Errorf("The Protocol field cannot be larger than %d, please choose another value (suggested: 1024)", MaxFrameProtocol)
+
+// ErrFrameOriginOverflow is the error returned when the Frame.Origin value is too large
+var ErrFrameOriginOverflow = fmt.Errorf("The Origin field cannot be larger than %d; should be set to 0", MaxFrameOrigin)
+
+// Frame is a struct that contains some information about the message itself. This includes
+// things like:
+//
+// 		* the size of the message
+// 		* the LIFX protocol number
+// 		* use of the Frame Address target field
+// 		* Source identifier
+type Frame struct {
+	// Size of the entire message in bytes, including this field.
+	Size uint16
+
+	// Origin is the message origin indicator (must be 0)
+	// Only uses the low 2 bits
+	Origin uint8
+
+	// Tagged is used to determine the usage of the Frame Address target field
+	// If you are sending a message to all devices (e.g., service discovery) this
+	// value should be true and the FrameAddress target field should be zero
+	Tagged bool
+
+	// Message includes a target address (must be true)
+	Addressable bool
+
+	// Protocol number; must be 1024 -- if set to 0 it will be automatically set
+	// Only uses the low 12 bits
+	Protocol uint16
+
+	// Source identifier: unique value set by the client, used by responses
+	Source uint32
+}
+
+// NewFrame is a function for returning a *Frame with sane (protocol compliant) default set.
+func NewFrame() *Frame {
+	return &Frame{
+		Origin:      0,
+		Addressable: true,
+		Protocol:    1024,
+	}
+}
+
+// MarshalPacket is a function that satisfies the ProtocolComponent interface. It takes the
+// fields of the Frame struct and renders them to a byte slice for use in a UDP packet. The
+// order parameter can either be binary.LittleEndian or binary.BigEndian. The LIFX protocol
+// uses little-endian encoding at the time of writing.
+func (frame *Frame) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	if frame.Origin > MaxFrameOrigin {
+		return nil, ErrFrameOriginOverflow
+	}
+
+	if frame.Protocol > MaxFrameProtocol {
+		return nil, ErrFrameProtocolOverflow
+	}
+
+	// TODO: enforce this in the consumer:
+	// according to the protocol spec this value should be 1 (true)
+	// https://github.com/LIFX/lifx-protocol-docs/blob/3de97af19703d49a97246267f08dbfd143118db0/header.md
+	// if frame.Addressable == false {
+	// 	frame.Addressable = true
+	// }
+
+	buf := &bytes.Buffer{}
+
+	// write the Size field
+	if err := binary.Write(buf, order, frame.Size); err != nil {
+		return nil, err
+	}
+
+	// the next 16 bit value is multiple fields packed together:
+	// Origin: 2
+	// Tagged: 1
+	// Addressable: 1
+	// Protocol: 12
+	mid := uint16(frame.Origin)<<14 | frame.Protocol<<4>>4
+
+	// if Tagged set the 13th bit in mid
+	if frame.Tagged {
+		mid = mid | (1 << 13)
+	}
+
+	// if Addressable set the 12th bit in mid
+	if frame.Addressable {
+		mid = mid | (1 << 12)
+	}
+
+	// write the combination value
+	if err := binary.Write(buf, order, mid); err != nil {
+		return nil, err
+	}
+
+	// write the Source field
+	if err := binary.Write(buf, order, frame.Source); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket takes an io.Reader and pulls unmarshals the packet in to the Frame
+// struct fields. It uses the order parameter to correctly unpack the values.
+func (frame *Frame) UnmarshalPacket(data io.Reader, order binary.ByteOrder) error {
+	if err := binary.Read(data, order, &frame.Size); err != nil {
+		return err
+	}
+
+	var u16 uint16
+
+	if err := binary.Read(data, order, &u16); err != nil {
+		return err
+	}
+
+	frame.Origin = uint8(u16 >> 14)    // get top 2 bits
+	frame.Tagged = u16>>13&1 == 1      // get 3rd bit and eval if it's true
+	frame.Addressable = u16>>12&1 == 1 // get 4th bit and eval if it's true
+	frame.Protocol = u16 << 4 >> 4     // get bottom 12 bits
+
+	if err := binary.Read(data, order, &frame.Source); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/protocol/frame_address.go
+++ b/protocol/frame_address.go
@@ -1,0 +1,171 @@
+package lifxprotocol
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+)
+
+// MaxFrameAddressReserved is the max size of the FrameAddress.Reserved
+// field. It only uses the top 6 bits so the maximum value is 63.
+const MaxFrameAddressReserved = ^uint8(0) >> 2
+
+// FrameAddressByteSize is the number of bytes in a marshaled FrameAddress struct
+const FrameAddressByteSize int = 16
+
+// ErrFrameAddressReservedOverflow is the error returned when the FrameAddress.Reserved value is too large.
+//
+// Also, what is this... Java?
+var ErrFrameAddressReservedOverflow = fmt.Errorf("The Reserved field cannot be larger than %d, suggested value is 0", MaxFrameAddressReserved)
+
+// ErrFrameAddressTargetMalformed is the error returned when the Target field is malformed. In other
+// words, it does not contain exactly 6 bytes.
+var ErrFrameAddressTargetMalformed = errors.New("The Target byte slice is malformed; the slice must contain 6 bytes")
+
+// FrameAddress is a struct that contains information about the following things:
+//
+// 		* target device address
+// 		* flag specifying whether an ack message is required
+// 		* flag specifying whether a state response message is required
+// 		* message sequence number
+type FrameAddress struct {
+	// Target is the devide address (MAC address) we are targetting this packet for.
+	// As the device address is a MAC address, this byte slice should consist of 6
+	// bytes. If we want to target all devices, this slice should either be empty/nil
+	// or 6 bytes with a value of 0.
+	//
+	// The underlying protocol spec defines this as an 8 byte (uint64) value with
+	// the right two-most bytes appearing to be used for padding. While the right-most
+	// two bytes look to be used for padding purposes, the spec does not explicitly
+	// define them as padding. This slice can be 8 bytes in length *ONLY* if the
+	// last two bytes (indicies 6 and 7) are zero (0). This is only to retain some
+	// compatibility with how the spec is written.
+	Target net.HardwareAddr
+
+	// ReservedBlock is reserved space; must all be zero
+	// This entire space equals 48 bits
+	ReservedBlock [6]uint8
+
+	// Reserved space specified by the protocol definition
+	// This uses the low 6 bits
+	Reserved uint8
+
+	// AckRequired: acknowledgement message is required
+	AckRequired bool
+
+	// ResRequired: response message is required
+	ResRequired bool
+
+	// Sequence is a wrap-around message sequence number
+	Sequence uint8
+}
+
+func NewFrameAddress() *FrameAddress { return &FrameAddress{} }
+
+func (fra *FrameAddress) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	if fra.Reserved > MaxFrameAddressReserved {
+		return nil, ErrFrameAddressReservedOverflow
+	}
+
+	var ack, res uint8
+
+	buf := new(bytes.Buffer)
+
+	var u64 uint64
+
+	// if the length of the target slice is 6
+	// or if the length of the target slice is 8
+	//    and byte 7 == 0 and byte 8 == 0
+	if len(fra.Target) == 6 ||
+		(len(fra.Target) == 8 && fra.Target[6] == 0 && fra.Target[7] == 0) {
+		u64 = targetSliceToUint(fra.Target)
+	} else {
+
+	}
+
+	if err := binary.Write(buf, order, u64); err != nil {
+		return nil, err
+	}
+
+	for _, value := range fra.ReservedBlock {
+		if err := binary.Write(buf, order, value); err != nil {
+			return nil, err
+		}
+	}
+
+	if fra.AckRequired {
+		ack = 1
+	}
+
+	if fra.ResRequired {
+		res = 1
+	}
+
+	// the next 8 bit chunk consists of multifple fields:
+	// Reserved: 6
+	// AckRequired: 1
+	// ResponseRequired: 1
+	u8 := fra.Reserved<<2 |
+		ack<<1 | res
+
+	if err := binary.Write(buf, order, u8); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, fra.Sequence); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (fra *FrameAddress) UnmarshalPacket(data io.Reader, order binary.ByteOrder) error {
+	var u64 uint64
+
+	if err := binary.Read(data, order, &u64); err != nil {
+		return err
+	}
+
+	fra.Target = uintToTargetSlice(u64)
+
+	for i := range fra.ReservedBlock {
+		if err := binary.Read(data, order, &fra.ReservedBlock[i]); err != nil {
+			return err
+		}
+	}
+
+	var u8 uint8
+
+	if err := binary.Read(data, order, &u8); err != nil {
+		return err
+	}
+
+	fra.Reserved = u8 >> 2         // get top 6 bits
+	fra.AckRequired = u8>>1&1 == 1 // get 7th bit and eval if it's true
+	fra.ResRequired = u8&1 == 1    // get 8th bit and eval if it's true
+
+	return binary.Read(data, order, &fra.Sequence)
+}
+
+func targetSliceToUint(target net.HardwareAddr) uint64 {
+	return uint64(target[0])<<55 |
+		uint64(target[1])<<47 |
+		uint64(target[2])<<39 |
+		uint64(target[3])<<31 |
+		uint64(target[4])<<23 |
+		uint64(target[5])<<15
+}
+
+func uintToTargetSlice(u64 uint64) net.HardwareAddr {
+	hwaddr := make(net.HardwareAddr, 6)
+	hwaddr[0] = byte(u64 >> 55)
+	hwaddr[1] = byte(u64 >> 47)
+	hwaddr[2] = byte(u64 >> 39)
+	hwaddr[3] = byte(u64 >> 31)
+	hwaddr[4] = byte(u64 >> 23)
+	hwaddr[5] = byte(u64 >> 15)
+	return hwaddr
+}

--- a/protocol/frame_address_test.go
+++ b/protocol/frame_address_test.go
@@ -1,0 +1,211 @@
+package lifxprotocol
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	. "gopkg.in/check.v1"
+)
+
+func (t *TestSuite) Test_NewFrameAddress(c *C) {
+	var fa *FrameAddress
+	fa = NewFrameAddress()
+	c.Assert(fa, Not(IsNil))
+}
+
+func (t *TestSuite) TestFrameAddress_MarshalPacket(c *C) {
+	var packet []byte
+	var err error
+	var u64 uint64
+	var u8 uint8
+
+	//
+	// Test that Marshaling works
+	//
+	fraddr := &FrameAddress{
+		Target:        []byte{0, 0, 0, 0, 0, 0},
+		ReservedBlock: [6]uint8{0, 0, 0, 0, 0, 0},
+		Reserved:      10,
+		AckRequired:   false,
+		ResRequired:   true,
+		Sequence:      42,
+	}
+
+	packet, err = fraddr.MarshalPacket(binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Assert(packet, Not(IsNil))
+	c.Check(len(packet), Equals, FrameAddressByteSize)
+
+	reader := bytes.NewReader(packet)
+
+	// Read the target field
+	err = binary.Read(reader, binary.LittleEndian, &u64)
+	c.Assert(err, IsNil)
+	c.Check(u64, Equals, uint64(0))
+
+	// Read the 6 reserved uint8 blocks
+	for i := 0; i < 6; i++ {
+		err = binary.Read(reader, binary.LittleEndian, &u8)
+		c.Assert(err, IsNil)
+		c.Check(u8, Equals, uint8(0))
+	}
+
+	// Read the single uint8 reserved block
+	err = binary.Read(reader, binary.LittleEndian, &u8)
+	c.Assert(err, IsNil)
+	c.Check(u8>>2, Equals, uint8(10))
+	c.Check(u8>>1&1, Equals, uint8(0))
+	c.Check(u8&1, Equals, uint8(1))
+
+	// Read the sequence field
+	err = binary.Read(reader, binary.LittleEndian, &u8)
+	c.Assert(err, IsNil)
+	c.Check(u8, Equals, uint8(42))
+
+	//
+	// Test that Marshaling works with different fields
+	//
+	fraddr = &FrameAddress{
+		Target:        []byte{65, 66, 67, 49, 50, 51},
+		ReservedBlock: [6]uint8{1, 2, 3, 4, 5, 6},
+		Reserved:      11,
+		AckRequired:   true,
+		ResRequired:   false,
+		Sequence:      22,
+	}
+
+	packet, err = fraddr.MarshalPacket(binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Assert(packet, Not(IsNil))
+	c.Check(len(packet), Equals, FrameAddressByteSize)
+
+	reader = bytes.NewReader(packet)
+
+	// Read the target field
+	err = binary.Read(reader, binary.LittleEndian, &u64)
+	c.Assert(err, IsNil)
+	c.Check(u64, Equals, uint64(2351197419751440384))
+
+	// Read the 6 reserved uint8 blocks
+	for i := 0; i < 6; i++ {
+		err = binary.Read(reader, binary.LittleEndian, &u8)
+		c.Assert(err, IsNil)
+		c.Check(u8, Equals, uint8(i+1))
+	}
+
+	// Read the single uint8 reserved block
+	err = binary.Read(reader, binary.LittleEndian, &u8)
+	c.Assert(err, IsNil)
+	c.Check(u8>>2, Equals, uint8(11))
+	c.Check(u8>>1&1, Equals, uint8(1))
+	c.Check(u8&1, Equals, uint8(0))
+
+	// Read the sequence field
+	err = binary.Read(reader, binary.LittleEndian, &u8)
+	c.Assert(err, IsNil)
+	c.Check(u8, Equals, uint8(22))
+}
+
+func (t *TestSuite) TestFrameAddress_UnmarshalPacket(c *C) {
+	var err error
+	var u64 uint64
+	var u8 uint8
+
+	buf := new(bytes.Buffer)
+
+	u64 = uint64(65)<<55 |
+		uint64(66)<<47 |
+		uint64(67)<<39 |
+		uint64(49)<<31 |
+		uint64(50)<<23 |
+		uint64(51)<<15
+
+	err = binary.Write(buf, binary.LittleEndian, u64)
+	c.Assert(err, IsNil)
+
+	for i := 0; i < 6; i++ {
+		err = binary.Write(buf, binary.LittleEndian, uint8(i))
+		c.Assert(err, IsNil)
+	}
+
+	u8 = 20<<2 | 1<<1 | 1&1
+	err = binary.Write(buf, binary.LittleEndian, u8)
+	c.Assert(err, IsNil)
+
+	err = binary.Write(buf, binary.LittleEndian, uint8(42))
+	c.Assert(err, IsNil)
+
+	//
+	// Test that Unmarshaling works
+	//
+	fra := &FrameAddress{}
+
+	err = fra.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Assert(len(fra.Target), Equals, 6)
+	c.Check(fra.Target[0], Equals, byte(65))
+	c.Check(fra.Target[1], Equals, byte(66))
+	c.Check(fra.Target[2], Equals, byte(67))
+	c.Check(fra.Target[3], Equals, byte(49))
+	c.Check(fra.Target[4], Equals, byte(50))
+	c.Check(fra.Target[5], Equals, byte(51))
+	c.Check(fra.ReservedBlock[0], Equals, uint8(0))
+	c.Check(fra.ReservedBlock[1], Equals, uint8(1))
+	c.Check(fra.ReservedBlock[2], Equals, uint8(2))
+	c.Check(fra.ReservedBlock[3], Equals, uint8(3))
+	c.Check(fra.ReservedBlock[4], Equals, uint8(4))
+	c.Check(fra.ReservedBlock[5], Equals, uint8(5))
+	c.Check(fra.Reserved, Equals, uint8(20))
+	c.Check(fra.AckRequired, Equals, true)
+	c.Check(fra.ResRequired, Equals, true)
+	c.Check(fra.Sequence, Equals, uint8(42))
+
+	buf = new(bytes.Buffer)
+
+	u64 = uint64(65)<<55 |
+		uint64(66)<<47 |
+		uint64(67)<<39 |
+		uint64(49)<<31 |
+		uint64(50)<<23 |
+		uint64(51)<<15
+
+	err = binary.Write(buf, binary.LittleEndian, u64)
+	c.Assert(err, IsNil)
+
+	for i := 0; i < 6; i++ {
+		err = binary.Write(buf, binary.LittleEndian, uint8(i+1))
+		c.Assert(err, IsNil)
+	}
+
+	u8 = 20<<2 | 0<<1 | 0&1
+	err = binary.Write(buf, binary.LittleEndian, u8)
+	c.Assert(err, IsNil)
+
+	err = binary.Write(buf, binary.LittleEndian, uint8(42))
+	c.Assert(err, IsNil)
+
+	//
+	// Test that Unmarshaling works with different inputs
+	//
+	fra = &FrameAddress{}
+
+	err = fra.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Assert(len(fra.Target), Equals, 6)
+	c.Check(fra.Target[0], Equals, byte(65))
+	c.Check(fra.Target[1], Equals, byte(66))
+	c.Check(fra.Target[2], Equals, byte(67))
+	c.Check(fra.Target[3], Equals, byte(49))
+	c.Check(fra.Target[4], Equals, byte(50))
+	c.Check(fra.Target[5], Equals, byte(51))
+	c.Check(fra.ReservedBlock[0], Equals, uint8(1))
+	c.Check(fra.ReservedBlock[1], Equals, uint8(2))
+	c.Check(fra.ReservedBlock[2], Equals, uint8(3))
+	c.Check(fra.ReservedBlock[3], Equals, uint8(4))
+	c.Check(fra.ReservedBlock[4], Equals, uint8(5))
+	c.Check(fra.ReservedBlock[5], Equals, uint8(6))
+	c.Check(fra.Reserved, Equals, uint8(20))
+	c.Check(fra.AckRequired, Equals, false)
+	c.Check(fra.ResRequired, Equals, false)
+	c.Check(fra.Sequence, Equals, uint8(42))
+}

--- a/protocol/frame_test.go
+++ b/protocol/frame_test.go
@@ -1,0 +1,194 @@
+package lifxprotocol
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	. "gopkg.in/check.v1"
+)
+
+func (t *TestSuite) Test_NewFrame(c *C) {
+	var f *Frame
+	f = NewFrame()
+	c.Assert(f, Not(IsNil))
+	c.Check(f.Origin, Equals, uint8(0))
+	c.Check(f.Addressable, Equals, true)
+	c.Check(f.Protocol, Equals, uint16(1024))
+}
+
+func (t *TestSuite) TestFrame_MarshalPacket(c *C) {
+	var packet []byte
+	var err error
+	var u16 uint16
+	var u32 uint32
+
+	//
+	// Test that Marshaling works
+	//
+	frame := &Frame{
+		Size:        8,
+		Origin:      2,
+		Tagged:      true,
+		Addressable: false,
+		Protocol:    1024,
+		Source:      42,
+	}
+
+	packet, err = frame.MarshalPacket(binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Assert(packet, Not(IsNil))
+	c.Check(len(packet), Equals, FrameByteSize)
+
+	reader := bytes.NewReader(packet)
+
+	// Read the size field
+	err = binary.Read(reader, binary.LittleEndian, &u16)
+	c.Assert(err, IsNil)
+	c.Check(u16, Equals, uint16(8))
+
+	// Read the middle fields that are joined together
+	err = binary.Read(reader, binary.LittleEndian, &u16)
+	c.Assert(err, IsNil)
+	c.Check(uint8(u16>>14), Equals, uint8(2)) // Origin
+	c.Check(u16>>13&1, Equals, uint16(1))     // Tagged
+	c.Check(u16>>12&1, Equals, uint16(0))     // Addressable
+	c.Check(u16<<4>>4, Equals, uint16(1024))  // Protocol
+
+	// Read the Source field
+	err = binary.Read(reader, binary.LittleEndian, &u32)
+	c.Assert(err, IsNil)
+	c.Check(u32, Equals, uint32(42))
+
+	//
+	// Test that Marshaling works with some adjusted fields
+	//
+	frame = &Frame{
+		Size:        10,
+		Origin:      0,
+		Tagged:      false,
+		Addressable: true,
+		Protocol:    4095,
+		Source:      4242,
+	}
+
+	packet, err = frame.MarshalPacket(binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Assert(packet, Not(IsNil))
+	c.Check(len(packet), Equals, FrameByteSize)
+
+	reader = bytes.NewReader(packet)
+
+	// Read the size field
+	err = binary.Read(reader, binary.LittleEndian, &u16)
+	c.Assert(err, IsNil)
+	c.Check(u16, Equals, uint16(10))
+
+	// Read the middle fields that are joined together
+	err = binary.Read(reader, binary.LittleEndian, &u16)
+	c.Assert(err, IsNil)
+	c.Check(uint8(u16>>14), Equals, uint8(0)) // Origin
+	c.Check(u16>>13&1, Equals, uint16(0))     // Tagged
+	c.Check(u16>>12&1, Equals, uint16(1))     // Addressable
+	c.Check(u16<<4>>4, Equals, uint16(4095))  // Protocol
+
+	// Read the Source field
+	err = binary.Read(reader, binary.LittleEndian, &u32)
+	c.Assert(err, IsNil)
+	c.Check(u32, Equals, uint32(4242))
+
+	//
+	// Test that overflowing the Origin field throws an error
+	//
+	frame = &Frame{
+		Size:        8,
+		Origin:      4,
+		Tagged:      false,
+		Addressable: false,
+		Protocol:    1024,
+		Source:      42,
+	}
+
+	packet, err = frame.MarshalPacket(binary.LittleEndian)
+	c.Check(err, Equals, ErrFrameOriginOverflow)
+	c.Check(packet, IsNil)
+
+	//
+	// Test that overflowing the Protocol field throws an error
+	//
+	frame = &Frame{
+		Size:        8,
+		Origin:      0,
+		Tagged:      false,
+		Addressable: false,
+		Protocol:    4096,
+		Source:      42,
+	}
+
+	packet, err = frame.MarshalPacket(binary.LittleEndian)
+	c.Check(err, Equals, ErrFrameProtocolOverflow)
+	c.Check(packet, IsNil)
+}
+
+func (t *TestSuite) TestFrame_UnmarshalPacket(c *C) {
+	var err error
+
+	origin := uint16(3)
+	tagged := uint16(1)
+	addressable := uint16(0)
+	protocol := uint16(1024)
+
+	u16 := origin<<14 |
+		tagged<<13 |
+		addressable<<12 |
+		protocol<<4>>4
+
+	buf := new(bytes.Buffer)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint16(8)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, u16), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(42)), IsNil)
+
+	//
+	// Test that Unmarshaling works
+	//
+	frame := &Frame{}
+
+	err = frame.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	c.Assert(err, IsNil)
+
+	c.Check(frame.Size, Equals, uint16(8))
+	c.Check(frame.Origin, Equals, uint8(origin))
+	c.Check(frame.Tagged, Equals, true)
+	c.Check(frame.Addressable, Equals, false)
+	c.Check(frame.Protocol, Equals, uint16(1024))
+	c.Check(frame.Source, Equals, uint32(42))
+
+	origin = uint16(0)
+	tagged = uint16(0)
+	addressable = uint16(1)
+	protocol = uint16(4095)
+
+	u16 = origin<<14 |
+		tagged<<13 |
+		addressable<<12 |
+		protocol<<4>>4
+
+	buf = new(bytes.Buffer)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint16(10)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, u16), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(4242)), IsNil)
+
+	//
+	// Test that Unmarshaling works with some adjusted fields
+	//
+	frame = &Frame{}
+
+	err = frame.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	c.Assert(err, IsNil)
+
+	c.Check(frame.Size, Equals, uint16(10))
+	c.Check(frame.Origin, Equals, uint8(origin))
+	c.Check(frame.Tagged, Equals, false)
+	c.Check(frame.Addressable, Equals, true)
+	c.Check(frame.Protocol, Equals, uint16(4095))
+	c.Check(frame.Source, Equals, uint32(4242))
+}

--- a/protocol/header.go
+++ b/protocol/header.go
@@ -1,0 +1,96 @@
+package lifxprotocol
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+)
+
+// Header is a struct that combines the individual portions of the header
+type Header struct {
+	// Frame is the header component that gives some information about
+	// the packet.
+	Frame *Frame
+
+	// FrameAddress is the component for defining the message target and
+	// some response requirements. It's recommended to use a *FrameAddress
+	// struct for this.
+	FrameAddress *FrameAddress
+
+	// ProtocolHeader is the component that contains information about
+	// the payload. It's recommended to use a *ProtocolHeader struct.
+	ProtocolHeader *ProtocolHeader
+}
+
+// MarshalPackage is a funtion that implements the ProtocolComponent interface.
+func (h *Header) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	if h.Frame == nil || h.FrameAddress == nil || h.ProtocolHeader == nil {
+		return nil, errors.New("none of the fields in the struct can be nil")
+	}
+
+	frame, err := h.Frame.MarshalPacket(order)
+
+	if err != nil {
+		return nil, err
+	}
+
+	frameAddress, err := h.FrameAddress.MarshalPacket(order)
+
+	if err != nil {
+		return nil, err
+	}
+
+	protocolHeader, err := h.ProtocolHeader.MarshalPacket(order)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// allocate the full slice now and manually set the bytes in loops
+	// later -- this is the most optimal way to do this
+	packet := make([]byte, len(frame)+len(frameAddress)+len(protocolHeader))
+
+	// pointer for the packet byte slice
+	// we use it to know which byte we are setting
+	var j int
+
+	// loop over the frame bytes and put them in the packet slice
+	// loop over the frameAddress bytes and put them in the packet slice
+	// using the j pointer to put the bytes in the right location within
+	// packet
+	for i := 0; i < len(frame); i++ {
+		packet[j] = frame[i]
+		j++ // move pointer
+	}
+
+	// loop over the frameAddress bytes and put them in the packet slice
+	for i := 0; i < len(frameAddress); i++ {
+		packet[j] = frameAddress[i]
+		j++
+	}
+
+	// loop over the protocolHeader bytes and put them in the packet slice
+	for i := 0; i < len(protocolHeader); i++ {
+		packet[j] = protocolHeader[i]
+		j++
+	}
+
+	return packet, nil
+}
+
+// UnmarshalPackage is a funtion that implements the ProtocolComponent interface.
+func (h *Header) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	if err = h.Frame.UnmarshalPacket(data, order); err != nil {
+		return
+	}
+
+	if err = h.FrameAddress.UnmarshalPacket(data, order); err != nil {
+		return
+	}
+
+	if err = h.ProtocolHeader.UnmarshalPacket(data, order); err != nil {
+		return
+	}
+
+	return
+}

--- a/protocol/header_test.go
+++ b/protocol/header_test.go
@@ -1,0 +1,191 @@
+package lifxprotocol
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	. "gopkg.in/check.v1"
+)
+
+func (*TestSuite) TestHeader_MarshalPacket(c *C) {
+	var packet []byte
+	var err error
+	var u64 uint64
+	var u32 uint32
+	var u16 uint16
+	var u8 uint8
+
+	frame := &Frame{
+		Size:        8,
+		Origin:      2,
+		Tagged:      true,
+		Addressable: false,
+		Protocol:    1024,
+		Source:      42,
+	}
+
+	fraddr := &FrameAddress{
+		Target:        []byte{0, 0, 0, 0, 0, 0},
+		ReservedBlock: [6]uint8{0, 0, 0, 0, 0, 0},
+		Reserved:      10,
+		AckRequired:   false,
+		ResRequired:   true,
+		Sequence:      42,
+	}
+
+	ph := &ProtocolHeader{
+		Reserved:    1,
+		Type:        2,
+		ReservedEnd: 3,
+	}
+
+	header := &Header{
+		Frame:          frame,
+		FrameAddress:   fraddr,
+		ProtocolHeader: ph,
+	}
+
+	packet, err = header.MarshalPacket(binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Assert(packet, Not(IsNil))
+
+	reader := bytes.NewReader(packet)
+
+	// Read the size field
+	err = binary.Read(reader, binary.LittleEndian, &u16)
+	c.Assert(err, IsNil)
+	c.Check(u16, Equals, uint16(8))
+
+	// Read the middle fields that are joined together
+	err = binary.Read(reader, binary.LittleEndian, &u16)
+	c.Assert(err, IsNil)
+	c.Check(uint8(u16>>14), Equals, uint8(2)) // Origin
+	c.Check(u16>>13&1, Equals, uint16(1))     // Tagged
+	c.Check(u16>>12&1, Equals, uint16(0))     // Addressable
+	c.Check(u16<<4>>4, Equals, uint16(1024))  // Protocol
+
+	// Read the Source field
+	err = binary.Read(reader, binary.LittleEndian, &u32)
+	c.Assert(err, IsNil)
+	c.Check(u32, Equals, uint32(42))
+
+	// Read the target field
+	err = binary.Read(reader, binary.LittleEndian, &u64)
+	c.Assert(err, IsNil)
+	c.Check(u64, Equals, uint64(0))
+
+	// Read the 6 reserved uint8 blocks
+	for i := 0; i < 6; i++ {
+		err = binary.Read(reader, binary.LittleEndian, &u8)
+		c.Assert(err, IsNil)
+		c.Check(u8, Equals, uint8(0))
+	}
+
+	// Read the single uint8 reserved block
+	err = binary.Read(reader, binary.LittleEndian, &u8)
+	c.Assert(err, IsNil)
+	c.Check(u8>>2, Equals, uint8(10))
+	c.Check(u8>>1&1, Equals, uint8(0))
+	c.Check(u8&1, Equals, uint8(1))
+
+	// Read the sequence field
+	err = binary.Read(reader, binary.LittleEndian, &u8)
+	c.Assert(err, IsNil)
+	c.Check(u8, Equals, uint8(42))
+
+	// read the first reserved block
+	err = binary.Read(reader, binary.LittleEndian, &u64)
+	c.Assert(err, IsNil)
+	c.Check(u64, Equals, uint64(1))
+
+	// read the type field
+	err = binary.Read(reader, binary.LittleEndian, &u16)
+	c.Assert(err, IsNil)
+	c.Check(u16, Equals, uint16(2))
+
+	// read the second reserved block
+	err = binary.Read(reader, binary.LittleEndian, &u16)
+	c.Assert(err, IsNil)
+	c.Check(u16, Equals, uint16(3))
+}
+
+func (*TestSuite) TestHeader_UnmarshalPacket(c *C) {
+	var err error
+	var u64 uint64
+	var u8 uint8
+
+	origin := uint16(3)
+	tagged := uint16(1)
+	addressable := uint16(0)
+	protocol := uint16(1024)
+
+	u16 := origin<<14 |
+		tagged<<13 |
+		addressable<<12 |
+		protocol<<4>>4
+
+	buf := &bytes.Buffer{}
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint16(8)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, u16), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(42)), IsNil)
+
+	u64 = uint64(65)<<55 |
+		uint64(66)<<47 |
+		uint64(67)<<39 |
+		uint64(49)<<31 |
+		uint64(50)<<23 |
+		uint64(51)<<15
+
+	c.Assert(binary.Write(buf, binary.LittleEndian, u64), IsNil)
+
+	for i := 0; i < 6; i++ {
+		c.Assert(binary.Write(buf, binary.LittleEndian, uint8(i)), IsNil)
+	}
+
+	u8 = 20<<2 | 1<<1 | 1&1
+	c.Assert(binary.Write(buf, binary.LittleEndian, u8), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint8(42)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(3)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint16(1)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(2)), IsNil)
+
+	frame := &Frame{}
+	fra := &FrameAddress{}
+	ph := &ProtocolHeader{}
+
+	header := &Header{
+		Frame:          frame,
+		FrameAddress:   fra,
+		ProtocolHeader: ph,
+	}
+
+	err = header.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	c.Assert(err, IsNil)
+
+	c.Check(frame.Size, Equals, uint16(8))
+	c.Check(frame.Origin, Equals, uint8(origin))
+	c.Check(frame.Tagged, Equals, true)
+	c.Check(frame.Addressable, Equals, false)
+	c.Check(frame.Protocol, Equals, uint16(1024))
+	c.Check(frame.Source, Equals, uint32(42))
+	c.Assert(len(fra.Target), Equals, 6)
+	c.Check(fra.Target[0], Equals, byte(65))
+	c.Check(fra.Target[1], Equals, byte(66))
+	c.Check(fra.Target[2], Equals, byte(67))
+	c.Check(fra.Target[3], Equals, byte(49))
+	c.Check(fra.Target[4], Equals, byte(50))
+	c.Check(fra.Target[5], Equals, byte(51))
+	c.Check(fra.ReservedBlock[0], Equals, uint8(0))
+	c.Check(fra.ReservedBlock[1], Equals, uint8(1))
+	c.Check(fra.ReservedBlock[2], Equals, uint8(2))
+	c.Check(fra.ReservedBlock[3], Equals, uint8(3))
+	c.Check(fra.ReservedBlock[4], Equals, uint8(4))
+	c.Check(fra.ReservedBlock[5], Equals, uint8(5))
+	c.Check(fra.Reserved, Equals, uint8(20))
+	c.Check(fra.AckRequired, Equals, true)
+	c.Check(fra.ResRequired, Equals, true)
+	c.Check(fra.Sequence, Equals, uint8(42))
+	c.Check(ph.Reserved, Equals, uint64(3))
+	c.Check(ph.Type, Equals, uint16(1))
+	c.Check(ph.ReservedEnd, Equals, uint16(2))
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -1,0 +1,26 @@
+package lifxprotocol
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+// ProtocolComponent is the interface used for each component to implement.
+type ProtocolComponent interface {
+	MarshalPacket(order binary.ByteOrder) ([]byte, error)
+	UnmarshalPacket(data io.Reader, order binary.ByteOrder) error
+}
+
+// Packet is the struct for an individual message whether inbound or
+// outbound.
+type Packet struct {
+	// Header is the component of a packet that details who it is for,
+	// what it contains, and how the recipient is meant to reply to
+	// the packet.
+	Header *Header
+
+	// Payload is the message payload. The contents of the payload vary
+	// based on what is being sent. The recipient knows how to parse this
+	// message based on the value of the Header.ProtocolHeader.Type field.
+	Payload ProtocolComponent
+}

--- a/protocol/protocol_header.go
+++ b/protocol/protocol_header.go
@@ -1,0 +1,104 @@
+package lifxprotocol
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+)
+
+// ProtocolHeaderByteSize is the number of bytes in a marshaled packet.
+const ProtocolHeaderByteSize int = 12
+
+const (
+	DeviceGetService        uint16 = 2
+	DeviceStateService      uint16 = 3
+	DeviceGetHostInfo       uint16 = 12
+	DeviceStateHostInfo     uint16 = 13
+	DeviceGetHostFirmware   uint16 = 14
+	DeviceStateHostFirmware uint16 = 15
+	DeviceGetWifiInfo       uint16 = 16
+	DeviceStateWifiInfo     uint16 = 17
+	DeviceGetWifiFirmware   uint16 = 18
+	DeviceStateWifiFirmware uint16 = 19
+	DeviceGetPower          uint16 = 20
+	DeviceSetPower          uint16 = 21
+	DeviceStatePower        uint16 = 22
+	DeviceGetLabel          uint16 = 23
+	DeviceSetLabel          uint16 = 24
+	DeviceStateLabel        uint16 = 25
+	DeviceGetVersion        uint16 = 32
+	DeviceStateVersion      uint16 = 33
+	DeviceGetInfo           uint16 = 34
+	DeviceStateInfo         uint16 = 35
+	DeviceAcknowledgement   uint16 = 45
+	DeviceGetLocation       uint16 = 48
+	DeviceStateLocation     uint16 = 50
+	DeviceGetGroup          uint16 = 51
+	DeviceStateGroup        uint16 = 53
+	DeviceEchoRequest       uint16 = 58
+	DeviceEchoResponse      uint16 = 59
+)
+
+const (
+	LightGet        uint16 = 101
+	LightSetColor   uint16 = 102
+	LightState      uint16 = 107
+	LightGetPower   uint16 = 116
+	LightSetPower   uint16 = 117
+	LightStatePower uint16 = 118
+)
+
+// ProtocolHeader is a struct that contains information about the payload contents
+// (i.e., what actions to take)
+type ProtocolHeader struct {
+	// Reserved is reserved according to the protocol documentation
+	Reserved uint64
+
+	// Type is the message type used to determine the message payload
+	Type uint16
+
+	// ReservedEnd is additional reserved space as defined by the protocol
+	// documentation
+	ReservedEnd uint16
+}
+
+func (ph *ProtocolHeader) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	// write the first reserved block
+	if err := binary.Write(buf, order, ph.Reserved); err != nil {
+		return nil, err
+	}
+
+	// write the type field, which indicates payload type
+	if err := binary.Write(buf, order, ph.Type); err != nil {
+		return nil, err
+	}
+
+	// write the last reserved block
+	if err := binary.Write(buf, order, ph.ReservedEnd); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that satisfies the ProtocolComponent interface.
+// It takes an io.Reader and pulls unmarshals the packet in to the
+// ProtocolHeader struct fields. It uses the order parameter to correctly
+// unpack the values.
+func (ph *ProtocolHeader) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	if err = binary.Read(data, order, &ph.Reserved); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &ph.Type); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &ph.ReservedEnd); err != nil {
+		return
+	}
+
+	return
+}

--- a/protocol/protocol_header_test.go
+++ b/protocol/protocol_header_test.go
@@ -1,0 +1,152 @@
+package lifxprotocol
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	. "gopkg.in/check.v1"
+)
+
+func (*TestSuite) TestProtocolHeaderDeviceTypes(c *C) {
+	c.Check(DeviceGetService, Equals, uint16(2))
+	c.Check(DeviceStateService, Equals, uint16(3))
+	c.Check(DeviceGetHostInfo, Equals, uint16(12))
+	c.Check(DeviceStateHostInfo, Equals, uint16(13))
+	c.Check(DeviceGetHostFirmware, Equals, uint16(14))
+	c.Check(DeviceStateHostFirmware, Equals, uint16(15))
+	c.Check(DeviceGetWifiInfo, Equals, uint16(16))
+	c.Check(DeviceStateWifiInfo, Equals, uint16(17))
+	c.Check(DeviceGetWifiFirmware, Equals, uint16(18))
+	c.Check(DeviceStateWifiFirmware, Equals, uint16(19))
+	c.Check(DeviceGetPower, Equals, uint16(20))
+	c.Check(DeviceSetPower, Equals, uint16(21))
+	c.Check(DeviceStatePower, Equals, uint16(22))
+	c.Check(DeviceGetLabel, Equals, uint16(23))
+	c.Check(DeviceSetLabel, Equals, uint16(24))
+	c.Check(DeviceStateLabel, Equals, uint16(25))
+	c.Check(DeviceGetVersion, Equals, uint16(32))
+	c.Check(DeviceStateVersion, Equals, uint16(33))
+	c.Check(DeviceGetInfo, Equals, uint16(34))
+	c.Check(DeviceStateInfo, Equals, uint16(35))
+	c.Check(DeviceAcknowledgement, Equals, uint16(45))
+	c.Check(DeviceGetLocation, Equals, uint16(48))
+	c.Check(DeviceStateLocation, Equals, uint16(50))
+	c.Check(DeviceGetGroup, Equals, uint16(51))
+	c.Check(DeviceStateGroup, Equals, uint16(53))
+	c.Check(DeviceEchoRequest, Equals, uint16(58))
+	c.Check(DeviceEchoResponse, Equals, uint16(59))
+}
+
+func (*TestSuite) TestProtocolHeaderLightTypes(c *C) {
+	c.Check(LightGet, Equals, uint16(101))
+	c.Check(LightSetColor, Equals, uint16(102))
+	c.Check(LightState, Equals, uint16(107))
+	c.Check(LightGetPower, Equals, uint16(116))
+	c.Check(LightSetPower, Equals, uint16(117))
+	c.Check(LightStatePower, Equals, uint16(118))
+}
+
+func (*TestSuite) TestProtocolHeader_MarshalPacket(c *C) {
+	var packet []byte
+	var err error
+	var u64 uint64
+	var u16 uint16
+
+	//
+	// Test that Marshaling works
+	//
+	ph := &ProtocolHeader{
+		Reserved:    1,
+		Type:        2,
+		ReservedEnd: 3,
+	}
+
+	packet, err = ph.MarshalPacket(binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Assert(packet, Not(IsNil))
+	c.Assert(len(packet), Equals, ProtocolHeaderByteSize)
+
+	reader := bytes.NewReader(packet)
+
+	// read the first reserved block
+	err = binary.Read(reader, binary.LittleEndian, &u64)
+	c.Assert(err, IsNil)
+	c.Check(u64, Equals, uint64(1))
+
+	// read the type field
+	err = binary.Read(reader, binary.LittleEndian, &u16)
+	c.Assert(err, IsNil)
+	c.Check(u16, Equals, uint16(2))
+
+	// read the second reserved block
+	err = binary.Read(reader, binary.LittleEndian, &u16)
+	c.Assert(err, IsNil)
+	c.Check(u16, Equals, uint16(3))
+
+	//
+	// Test that Marshaling works with different inputs
+	//
+	ph = &ProtocolHeader{
+		Reserved:    100,
+		Type:        42,
+		ReservedEnd: 3000,
+	}
+
+	packet, err = ph.MarshalPacket(binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Assert(packet, Not(IsNil))
+	c.Assert(len(packet), Equals, ProtocolHeaderByteSize)
+
+	reader = bytes.NewReader(packet)
+
+	// read the first reserved block
+	err = binary.Read(reader, binary.LittleEndian, &u64)
+	c.Assert(err, IsNil)
+	c.Check(u64, Equals, uint64(100))
+
+	// read the type field
+	err = binary.Read(reader, binary.LittleEndian, &u16)
+	c.Assert(err, IsNil)
+	c.Check(u16, Equals, uint16(42))
+
+	// read the second reserved block
+	err = binary.Read(reader, binary.LittleEndian, &u16)
+	c.Assert(err, IsNil)
+	c.Check(u16, Equals, uint16(3000))
+}
+
+func (*TestSuite) TestProtocolHeader_UnmarshalPacket(c *C) {
+	var err error
+
+	buf := &bytes.Buffer{}
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(3)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint16(1)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(2)), IsNil)
+
+	//
+	// Test that Unmarshaling works
+	//
+	ph := &ProtocolHeader{}
+
+	err = ph.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Check(ph.Reserved, Equals, uint64(3))
+	c.Check(ph.Type, Equals, uint16(1))
+	c.Check(ph.ReservedEnd, Equals, uint16(2))
+
+	buf.Reset()
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(42)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint16(84)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(9001)), IsNil)
+
+	//
+	// Test that Unmarshaling works with different inputs
+	//
+	ph = &ProtocolHeader{}
+
+	err = ph.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Check(ph.Reserved, Equals, uint64(42))
+	c.Check(ph.Type, Equals, uint16(84))
+	c.Check(ph.ReservedEnd, Equals, uint16(9001))
+}

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -1,0 +1,13 @@
+package lifxprotocol
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+type TestSuite struct{}
+
+var _ = Suite(&TestSuite{})
+
+func Test(t *testing.T) { TestingT(t) }


### PR DESCRIPTION
This change adds the ability to marshal and unmarshal the Header component of a LIFX message package. The Header includes things like the target, how the target should process the message and respond, as well as the type of payload. This does not include code to marshal the packet payload.
