### PR TITLE
add initial Device-specific payload structs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2015, Tim Heckman
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of linode-netint nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/protocol/payloads/device.go
+++ b/protocol/payloads/device.go
@@ -1,0 +1,278 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package lifxpayloads
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+)
+
+// DeviceStateService is the response to the DeviceGetService message.
+//
+// Provides the device Service and port. If the Service is temporarily
+// unavailable, then the port value will be 0.
+type DeviceStateService struct {
+	// Service describes the type of service exposed by the device.
+	// 		1: UDP
+	Service uint8
+
+	// Port is the port the device is listening on the network. For
+	// compatibility reasons it's recommended that clients bind to port
+	// 56700.
+	Port uint32
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dss *DeviceStateService) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	if err := binary.Write(buf, order, dss.Service); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, dss.Port); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dss *DeviceStateService) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	if err = binary.Read(data, order, &dss.Service); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &dss.Port); err != nil {
+		return
+	}
+
+	return
+}
+
+// DeviceStateHostInfo is the response to the DeviceGetHostInfo message.
+// It provides host MCU information.
+type DeviceStateHostInfo struct {
+	// Signal is the radio receive signal strength in milliwatts.
+	Signal float32
+
+	// Tx is the number of bytes transmitted since power on.
+	Tx uint32
+
+	// Rx is the number of bytes received since power on.
+	Rx uint32
+
+	Reserved int16
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dshi *DeviceStateHostInfo) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	if err := binary.Write(buf, order, dshi.Signal); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, dshi.Tx); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, dshi.Rx); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, dshi.Reserved); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dshi *DeviceStateHostInfo) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	if err = binary.Read(data, order, &dshi.Signal); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &dshi.Tx); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &dshi.Rx); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &dshi.Reserved); err != nil {
+		return
+	}
+
+	return
+}
+
+// DeviceStateHostFirmware is the response to the DeviceGetHosFirmware message.
+// This provides information about the host's firmware.
+type DeviceStateHostFirmware struct {
+	// Build is the firmware build time (absolute time in nanoseconds since epoch).
+	Build uint64
+
+	Reserved uint64
+
+	// Version is the firmware version of the host.
+	Version uint32
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dshf *DeviceStateHostFirmware) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	if err := binary.Write(buf, order, dshf.Build); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, dshf.Reserved); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, dshf.Version); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dshf *DeviceStateHostFirmware) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	if err = binary.Read(data, order, &dshf.Build); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &dshf.Reserved); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &dshf.Version); err != nil {
+		return
+	}
+
+	return
+}
+
+// DeviceStateWifiInfo is the response to the DeviceGetWifiInfo message.
+// It provides Wifi subsystem information.
+type DeviceStateWifiInfo struct {
+	// Signal is the radio receive signal strength in milliwatts
+	Signal float32
+
+	// Tx is the number of bytes transmitted since power on.
+	Tx uint32
+
+	// Rx is the nimber of bytes received since power on.
+	Rx uint32
+
+	Reserved int16
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dswi *DeviceStateWifiInfo) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	if err := binary.Write(buf, order, dswi.Signal); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, dswi.Tx); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, dswi.Rx); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, dswi.Reserved); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dswi *DeviceStateWifiInfo) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	if err = binary.Read(data, order, &dswi.Signal); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &dswi.Tx); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &dswi.Rx); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &dswi.Reserved); err != nil {
+		return
+	}
+
+	return
+}
+
+// DeviceStateWifiFirmware is the response to the GetWifiFirmware message.
+// This provides Wifi subsystem information.
+type DeviceStateWifiFirmware struct {
+	// Build is the firmware build time (absolute time in nanoseconds since epoch)
+	Build uint64
+
+	Reserved uint64
+
+	// Version is the subsystem firmware version.
+	Version uint32
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dswf *DeviceStateWifiFirmware) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	if err := binary.Write(buf, order, dswf.Build); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, dswf.Reserved); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, dswf.Version); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dswf *DeviceStateWifiFirmware) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	if err = binary.Read(data, order, &dswf.Build); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &dswf.Reserved); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &dswf.Version); err != nil {
+		return
+	}
+
+	return
+}

--- a/protocol/payloads/device_test.go
+++ b/protocol/payloads/device_test.go
@@ -1,0 +1,254 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package lifxpayloads
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	. "gopkg.in/check.v1"
+)
+
+func (*TestSuite) TestDeviceStateService_MarshalPacket(c *C) {
+	var packet []byte
+	var err error
+	var u32 uint32
+	var u8 uint8
+
+	dss := &DeviceStateService{
+		Service: 1,
+		Port:    56700,
+	}
+
+	packet, err = dss.MarshalPacket(binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Assert(packet, Not(IsNil))
+	c.Assert(len(packet), Equals, 5)
+
+	reader := bytes.NewReader(packet)
+
+	c.Assert(binary.Read(reader, binary.LittleEndian, &u8), IsNil)
+	c.Check(u8, Equals, uint8(1))
+	c.Assert(binary.Read(reader, binary.LittleEndian, &u32), IsNil)
+	c.Check(u32, Equals, uint32(56700))
+}
+
+func (*TestSuite) TestDeviceStateService_UnmarshalPacket(c *C) {
+	var err error
+
+	buf := &bytes.Buffer{}
+
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint8(42)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(8484)), IsNil)
+
+	dss := &DeviceStateService{}
+
+	err = dss.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Check(dss.Service, Equals, uint8(42))
+	c.Check(dss.Port, Equals, uint32(8484))
+}
+
+func (*TestSuite) TestDeviceStateHostInfo_MarshalPacket(c *C) {
+	var packet []byte
+	var err error
+	var f32 float32
+	var u32 uint32
+	var i16 int16
+
+	dshi := &DeviceStateHostInfo{
+		Signal:   42,
+		Tx:       22,
+		Rx:       44,
+		Reserved: 99,
+	}
+
+	packet, err = dshi.MarshalPacket(binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Assert(packet, Not(IsNil))
+	c.Assert(len(packet), Equals, 14)
+
+	reader := bytes.NewReader(packet)
+
+	c.Assert(binary.Read(reader, binary.LittleEndian, &f32), IsNil)
+	c.Check(f32, Equals, float32(42.0))
+
+	c.Assert(binary.Read(reader, binary.LittleEndian, &u32), IsNil)
+	c.Check(u32, Equals, uint32(22))
+
+	c.Assert(binary.Read(reader, binary.LittleEndian, &u32), IsNil)
+	c.Check(u32, Equals, uint32(44))
+
+	c.Assert(binary.Read(reader, binary.LittleEndian, &i16), IsNil)
+	c.Check(i16, Equals, int16(99))
+}
+
+func (*TestSuite) TestDeviceStateHostInfo_UnmarshalPacket(c *C) {
+	var err error
+
+	buf := &bytes.Buffer{}
+
+	c.Assert(binary.Write(buf, binary.LittleEndian, float32(88)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(55)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(77)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, int16(66)), IsNil)
+
+	dshi := &DeviceStateHostInfo{}
+
+	err = dshi.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Check(dshi.Signal, Equals, float32(88))
+	c.Check(dshi.Tx, Equals, uint32(55))
+	c.Check(dshi.Rx, Equals, uint32(77))
+	c.Check(dshi.Reserved, Equals, int16(66))
+}
+
+func (*TestSuite) TestDeviceStateHostFirmware_MarshalPacket(c *C) {
+	var packet []byte
+	var err error
+	var u64 uint64
+	var u32 uint32
+
+	dshf := &DeviceStateHostFirmware{
+		Build:    100,
+		Reserved: 30,
+		Version:  200,
+	}
+
+	packet, err = dshf.MarshalPacket(binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Assert(packet, Not(IsNil))
+	c.Assert(len(packet), Equals, 20)
+
+	reader := bytes.NewReader(packet)
+
+	c.Assert(binary.Read(reader, binary.LittleEndian, &u64), IsNil)
+	c.Check(u64, Equals, uint64(100))
+
+	c.Assert(binary.Read(reader, binary.LittleEndian, &u64), IsNil)
+	c.Check(u64, Equals, uint64(30))
+
+	c.Assert(binary.Read(reader, binary.LittleEndian, &u32), IsNil)
+	c.Check(u32, Equals, uint32(200))
+}
+
+func (*TestSuite) TestDeviceStateHostFirmware_UnmarshalPacket(c *C) {
+	var err error
+
+	buf := &bytes.Buffer{}
+
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(42)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(84)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(99)), IsNil)
+
+	dshf := &DeviceStateHostFirmware{}
+
+	err = dshf.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Check(dshf.Build, Equals, uint64(42))
+	c.Check(dshf.Reserved, Equals, uint64(84))
+	c.Check(dshf.Version, Equals, uint32(99))
+}
+
+func (*TestSuite) TestDeviceStateWifiInfo_MarshalPacket(c *C) {
+	var packet []byte
+	var err error
+	var f32 float32
+	var u32 uint32
+	var i16 int16
+
+	dswi := &DeviceStateWifiInfo{
+		Signal:   42,
+		Tx:       22,
+		Rx:       44,
+		Reserved: 99,
+	}
+
+	packet, err = dswi.MarshalPacket(binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Assert(packet, Not(IsNil))
+	c.Assert(len(packet), Equals, 14)
+
+	reader := bytes.NewReader(packet)
+
+	c.Assert(binary.Read(reader, binary.LittleEndian, &f32), IsNil)
+	c.Check(f32, Equals, float32(42.0))
+
+	c.Assert(binary.Read(reader, binary.LittleEndian, &u32), IsNil)
+	c.Check(u32, Equals, uint32(22))
+
+	c.Assert(binary.Read(reader, binary.LittleEndian, &u32), IsNil)
+	c.Check(u32, Equals, uint32(44))
+
+	c.Assert(binary.Read(reader, binary.LittleEndian, &i16), IsNil)
+	c.Check(i16, Equals, int16(99))
+}
+
+func (*TestSuite) TestDeviceStateWifiInfo_UnmarshalPacket(c *C) {
+	var err error
+
+	buf := &bytes.Buffer{}
+
+	c.Assert(binary.Write(buf, binary.LittleEndian, float32(88)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(55)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(77)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, int16(66)), IsNil)
+
+	dswi := &DeviceStateWifiInfo{}
+
+	err = dswi.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Check(dswi.Signal, Equals, float32(88))
+	c.Check(dswi.Tx, Equals, uint32(55))
+	c.Check(dswi.Rx, Equals, uint32(77))
+	c.Check(dswi.Reserved, Equals, int16(66))
+}
+
+func (*TestSuite) TestDeviceStateWifiFirmware_MarshalPacket(c *C) {
+	var packet []byte
+	var err error
+	var u64 uint64
+	var u32 uint32
+
+	dswf := &DeviceStateWifiFirmware{
+		Build:    100,
+		Reserved: 30,
+		Version:  200,
+	}
+
+	packet, err = dswf.MarshalPacket(binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Assert(packet, Not(IsNil))
+	c.Assert(len(packet), Equals, 20)
+
+	reader := bytes.NewReader(packet)
+
+	c.Assert(binary.Read(reader, binary.LittleEndian, &u64), IsNil)
+	c.Check(u64, Equals, uint64(100))
+
+	c.Assert(binary.Read(reader, binary.LittleEndian, &u64), IsNil)
+	c.Check(u64, Equals, uint64(30))
+
+	c.Assert(binary.Read(reader, binary.LittleEndian, &u32), IsNil)
+	c.Check(u32, Equals, uint32(200))
+}
+
+func (*TestSuite) TestDeviceStateWifiFirmware_UnmarshalPacket(c *C) {
+	var err error
+
+	buf := &bytes.Buffer{}
+
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(42)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(84)), IsNil)
+	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(99)), IsNil)
+
+	dswf := &DeviceStateWifiFirmware{}
+
+	err = dswf.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	c.Assert(err, IsNil)
+	c.Check(dswf.Build, Equals, uint64(42))
+	c.Check(dswf.Reserved, Equals, uint64(84))
+	c.Check(dswf.Version, Equals, uint32(99))
+}

--- a/protocol/payloads/payloads_test.go
+++ b/protocol/payloads/payloads_test.go
@@ -1,0 +1,17 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package lifxpayloads
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+type TestSuite struct{}
+
+var _ = Suite(&TestSuite{})
+
+func Test(t *testing.T) { TestingT(t) }


### PR DESCRIPTION
There are quite a few different message payloads, and not many have anything in common so composition isn't much of an option. There are more payloads to be added.

In addition, I realized I forgot to add a `LICENSE` file so let's release this under the BSD 3-Clause license.
