### PR TITLE
add some package information for GoDoc; add LICENSE file header

### DIFF
--- a/protocol/frame.go
+++ b/protocol/frame.go
@@ -1,3 +1,7 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
 package lifxprotocol
 
 import (

--- a/protocol/frame_address.go
+++ b/protocol/frame_address.go
@@ -1,3 +1,7 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
 package lifxprotocol
 
 import (

--- a/protocol/frame_address_test.go
+++ b/protocol/frame_address_test.go
@@ -1,3 +1,7 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
 package lifxprotocol
 
 import (

--- a/protocol/frame_test.go
+++ b/protocol/frame_test.go
@@ -1,3 +1,7 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
 package lifxprotocol
 
 import (

--- a/protocol/header.go
+++ b/protocol/header.go
@@ -1,3 +1,7 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
 package lifxprotocol
 
 import (

--- a/protocol/header_test.go
+++ b/protocol/header_test.go
@@ -1,3 +1,7 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
 package lifxprotocol
 
 import (

--- a/protocol/payloads/payloads.go
+++ b/protocol/payloads/payloads.go
@@ -1,0 +1,13 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+// Package lifxpayloads is used for marshaling and unmarshaling different LIFX
+// protocol payloads to and from the wire, respectively. This package is not
+// meant to be consumed by those wanting to interface with their LIFX devices
+// in Golang. This package is designed to be used by the LIFX Golang library
+// for communicating with devices. Users are meant to consume that package.
+//
+// At the time of writing, the main LIFX Go package does not exist. This
+// package is a prerequisite for the client package.
+package lifxpayloads

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -1,3 +1,16 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+// Package lifxprotocol is used for marshaling and unmarshaling different LIFX
+// protocol packets to and from the wire, respectively. This package is not
+// meant to be consumed by those wanting to interface with their LIFX devices
+// in Golang. This package is designed to be used by the LIFX Golang library
+// for communicating with devices. Users are meant to consume that package
+// (which unfortunately doesn't exist, yet).
+//
+// This package uses the lifpayloads sub-package to generate payloads for
+// the individual packets.
 package lifxprotocol
 
 import (

--- a/protocol/protocol_header.go
+++ b/protocol/protocol_header.go
@@ -1,3 +1,7 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
 package lifxprotocol
 
 import (

--- a/protocol/protocol_header_test.go
+++ b/protocol/protocol_header_test.go
@@ -1,3 +1,7 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
 package lifxprotocol
 
 import (

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -1,3 +1,7 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
 package lifxprotocol
 
 import (


### PR DESCRIPTION
This adds some package information for GoDoc for the `lifxprotocol` and `lifxpayloads` packages. In addition, the LICENSE header has been added to additional files.
