### PR TITLE
improve tests where we expect it not to be nil

### DIFF
--- a/protocol/frame_address_test.go
+++ b/protocol/frame_address_test.go
@@ -14,7 +14,7 @@ import (
 func (t *TestSuite) Test_NewFrameAddress(c *C) {
 	var fa *FrameAddress
 	fa = NewFrameAddress()
-	c.Assert(fa, Not(IsNil))
+	c.Assert(fa, NotNil)
 }
 
 func (t *TestSuite) TestFrameAddress_MarshalPacket(c *C) {
@@ -37,7 +37,7 @@ func (t *TestSuite) TestFrameAddress_MarshalPacket(c *C) {
 
 	packet, err = fraddr.MarshalPacket(binary.LittleEndian)
 	c.Assert(err, IsNil)
-	c.Assert(packet, Not(IsNil))
+	c.Assert(packet, NotNil)
 	c.Check(len(packet), Equals, FrameAddressByteSize)
 
 	reader := bytes.NewReader(packet)
@@ -80,7 +80,7 @@ func (t *TestSuite) TestFrameAddress_MarshalPacket(c *C) {
 
 	packet, err = fraddr.MarshalPacket(binary.LittleEndian)
 	c.Assert(err, IsNil)
-	c.Assert(packet, Not(IsNil))
+	c.Assert(packet, NotNil)
 	c.Check(len(packet), Equals, FrameAddressByteSize)
 
 	reader = bytes.NewReader(packet)

--- a/protocol/frame_test.go
+++ b/protocol/frame_test.go
@@ -14,7 +14,7 @@ import (
 func (t *TestSuite) Test_NewFrame(c *C) {
 	var f *Frame
 	f = NewFrame()
-	c.Assert(f, Not(IsNil))
+	c.Assert(f, NotNil)
 	c.Check(f.Origin, Equals, uint8(0))
 	c.Check(f.Addressable, Equals, true)
 	c.Check(f.Protocol, Equals, uint16(1024))
@@ -40,7 +40,7 @@ func (t *TestSuite) TestFrame_MarshalPacket(c *C) {
 
 	packet, err = frame.MarshalPacket(binary.LittleEndian)
 	c.Assert(err, IsNil)
-	c.Assert(packet, Not(IsNil))
+	c.Assert(packet, NotNil)
 	c.Check(len(packet), Equals, FrameByteSize)
 
 	reader := bytes.NewReader(packet)
@@ -77,7 +77,7 @@ func (t *TestSuite) TestFrame_MarshalPacket(c *C) {
 
 	packet, err = frame.MarshalPacket(binary.LittleEndian)
 	c.Assert(err, IsNil)
-	c.Assert(packet, Not(IsNil))
+	c.Assert(packet, NotNil)
 	c.Check(len(packet), Equals, FrameByteSize)
 
 	reader = bytes.NewReader(packet)

--- a/protocol/header_test.go
+++ b/protocol/header_test.go
@@ -51,7 +51,7 @@ func (*TestSuite) TestHeader_MarshalPacket(c *C) {
 
 	packet, err = header.MarshalPacket(binary.LittleEndian)
 	c.Assert(err, IsNil)
-	c.Assert(packet, Not(IsNil))
+	c.Assert(packet, NotNil)
 
 	reader := bytes.NewReader(packet)
 

--- a/protocol/payloads/device_test.go
+++ b/protocol/payloads/device_test.go
@@ -24,7 +24,7 @@ func (*TestSuite) TestDeviceStateService_MarshalPacket(c *C) {
 
 	packet, err = dss.MarshalPacket(binary.LittleEndian)
 	c.Assert(err, IsNil)
-	c.Assert(packet, Not(IsNil))
+	c.Assert(packet, NotNil)
 	c.Assert(len(packet), Equals, 5)
 
 	reader := bytes.NewReader(packet)
@@ -67,7 +67,7 @@ func (*TestSuite) TestDeviceStateHostInfo_MarshalPacket(c *C) {
 
 	packet, err = dshi.MarshalPacket(binary.LittleEndian)
 	c.Assert(err, IsNil)
-	c.Assert(packet, Not(IsNil))
+	c.Assert(packet, NotNil)
 	c.Assert(len(packet), Equals, 14)
 
 	reader := bytes.NewReader(packet)
@@ -119,7 +119,7 @@ func (*TestSuite) TestDeviceStateHostFirmware_MarshalPacket(c *C) {
 
 	packet, err = dshf.MarshalPacket(binary.LittleEndian)
 	c.Assert(err, IsNil)
-	c.Assert(packet, Not(IsNil))
+	c.Assert(packet, NotNil)
 	c.Assert(len(packet), Equals, 20)
 
 	reader := bytes.NewReader(packet)
@@ -168,7 +168,7 @@ func (*TestSuite) TestDeviceStateWifiInfo_MarshalPacket(c *C) {
 
 	packet, err = dswi.MarshalPacket(binary.LittleEndian)
 	c.Assert(err, IsNil)
-	c.Assert(packet, Not(IsNil))
+	c.Assert(packet, NotNil)
 	c.Assert(len(packet), Equals, 14)
 
 	reader := bytes.NewReader(packet)
@@ -220,7 +220,7 @@ func (*TestSuite) TestDeviceStateWifiFirmware_MarshalPacket(c *C) {
 
 	packet, err = dswf.MarshalPacket(binary.LittleEndian)
 	c.Assert(err, IsNil)
-	c.Assert(packet, Not(IsNil))
+	c.Assert(packet, NotNil)
 	c.Assert(len(packet), Equals, 20)
 
 	reader := bytes.NewReader(packet)

--- a/protocol/protocol_header_test.go
+++ b/protocol/protocol_header_test.go
@@ -67,7 +67,7 @@ func (*TestSuite) TestProtocolHeader_MarshalPacket(c *C) {
 
 	packet, err = ph.MarshalPacket(binary.LittleEndian)
 	c.Assert(err, IsNil)
-	c.Assert(packet, Not(IsNil))
+	c.Assert(packet, NotNil)
 	c.Assert(len(packet), Equals, ProtocolHeaderByteSize)
 
 	reader := bytes.NewReader(packet)
@@ -98,7 +98,7 @@ func (*TestSuite) TestProtocolHeader_MarshalPacket(c *C) {
 
 	packet, err = ph.MarshalPacket(binary.LittleEndian)
 	c.Assert(err, IsNil)
-	c.Assert(packet, Not(IsNil))
+	c.Assert(packet, NotNil)
 	c.Assert(len(packet), Equals, ProtocolHeaderByteSize)
 
 	reader = bytes.NewReader(packet)


### PR DESCRIPTION
For some reason I was using `Not(IsNil)` instead of `NotNil`. This fixes that.
