### PR TITLE
add Light Message payloads; test go1.6rc2 (allowing failures)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: go
 go:
   - 1.5.3
+  - 1.6rc2
+matrix:
+  allow_failures:
+    - go: 1.6rc2
 script: go test -v ./... -check.vv
 sudo: false
 notifications:

--- a/protocol/payloads/lights.go
+++ b/protocol/payloads/lights.go
@@ -1,0 +1,317 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package lifxpayloads
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"time"
+)
+
+// the Duration field within the protocol specification determines how long an
+// action takes to finish -- this is in milliseconds and is a uint32 on the wire
+// so, we need to calculate the maximum Duration value we can support in uint32:
+// 49 days, 17 hours, 2 minutes, 47.295 seconds
+const lightMaxDuration = time.Millisecond * time.Duration(^uint32(0))
+
+// ErrLightColorNotSet is the error returned when the color is not set
+// on the strut trying to be marshaled.
+var ErrLightColorNotSet = errors.New("a *lifxpayloads.LightHSBK must be set on the Color field before marshaling")
+
+// LightHSBK is the struct used to represent the color and color temperature
+// of a light.
+//
+// The color is represented as an HSB (Hue, Saturation, and Brightness) value.
+type LightHSBK struct {
+	// Hue is range 0 to 65535
+	Hue uint16
+
+	// Saturation is a range from 0 to 65535
+	Saturation uint16
+
+	// Brightness is a range of 0 to 65535
+	Brightness uint16
+
+	// Kevin is the color temperature of the light. The lower the warmer
+	// (2500) the higher the cooler (9000).
+	Kelvin uint16
+}
+
+// LightSetColor is the struct representing the payload sent by a client
+// to change the light state.
+//
+// Duration is the time it takes to transition to the new state.
+type LightSetColor struct {
+	Reserved uint8
+	Color    *LightHSBK
+	Duration time.Duration
+}
+
+func durToMs(dur time.Duration) uint32 {
+	return uint32(dur / time.Millisecond)
+}
+
+func msToDur(ms uint32) time.Duration {
+	return time.Duration(ms) * time.Millisecond
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (lsc *LightSetColor) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	if lsc.Color == nil {
+		return nil, ErrLightColorNotSet
+	}
+
+	// if the length of the Duration would overflow uint32
+	if lsc.Duration > lightMaxDuration {
+		return nil, errors.New("LightSetColor.Duration would overflow uint32")
+	}
+
+	buf := &bytes.Buffer{}
+
+	if err := binary.Write(buf, order, lsc.Reserved); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, lsc.Color.Hue); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, lsc.Color.Saturation); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, lsc.Color.Brightness); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, lsc.Color.Kelvin); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, durToMs(lsc.Duration)); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (lsc *LightSetColor) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	if err = binary.Read(data, order, &lsc.Reserved); err != nil {
+		return
+	}
+
+	if lsc.Color == nil {
+		lsc.Color = &LightHSBK{}
+	}
+
+	if err = binary.Read(data, order, &lsc.Color.Hue); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &lsc.Color.Saturation); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &lsc.Color.Brightness); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &lsc.Color.Kelvin); err != nil {
+		return
+	}
+
+	var u32 uint32
+
+	if err = binary.Read(data, order, &u32); err != nil {
+		return
+	}
+
+	lsc.Duration = msToDur(u32)
+
+	return
+}
+
+// LightState is the struct representing the payload sent by the device
+// to preovide the current light state.
+type LightState struct {
+	Color    *LightHSBK
+	Reserved uint16
+
+	// Power is either 0 for off or 65535 for on
+	Power uint16
+
+	// Label is the user-identifiable name for the device.
+	Label [32]byte
+
+	ReservedB uint64
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (ls *LightState) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	if ls.Color == nil {
+		return nil, ErrLightColorNotSet
+	}
+
+	buf := &bytes.Buffer{}
+
+	if err := binary.Write(buf, order, ls.Color.Hue); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, ls.Color.Saturation); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, ls.Color.Brightness); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, ls.Color.Kelvin); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, ls.Reserved); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, ls.Power); err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < 32; i++ {
+		if err := binary.Write(buf, order, ls.Label[i]); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := binary.Write(buf, order, ls.ReservedB); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (ls *LightState) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	if ls.Color == nil {
+		ls.Color = &LightHSBK{}
+	}
+
+	if err = binary.Read(data, order, &ls.Color.Hue); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &ls.Color.Saturation); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &ls.Color.Brightness); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &ls.Color.Kelvin); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &ls.Reserved); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &ls.Power); err != nil {
+		return
+	}
+
+	for i := 0; i < 32; i++ {
+		if err = binary.Read(data, order, &ls.Label[i]); err != nil {
+			return
+		}
+	}
+
+	if err = binary.Read(data, order, &ls.ReservedB); err != nil {
+		return
+	}
+
+	return
+}
+
+// LightSetPower is a struct representing the message sent by a client to
+// change the light power level.
+type LightSetPower struct {
+	// Level must be either 0 or 65535
+	Level uint16
+
+	// Duration is the transition time for the level change.
+	Duration time.Duration
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (lsp *LightSetPower) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	// if the length of the Duration would overflow uint32
+	if lsp.Duration > lightMaxDuration {
+		return nil, errors.New("LightSetPower.Duration would overflow uint32")
+	}
+
+	buf := &bytes.Buffer{}
+
+	if err := binary.Write(buf, order, lsp.Level); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, durToMs(lsp.Duration)); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (lsp *LightSetPower) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	if err = binary.Read(data, order, &lsp.Level); err != nil {
+		return
+	}
+
+	var u32 uint32
+
+	if err = binary.Read(data, order, &u32); err != nil {
+		return
+	}
+
+	lsp.Duration = msToDur(u32)
+
+	return
+}
+
+// LightStatePower is the struct representing a messagent sent by a device
+// to provide the current power level.
+type LightStatePower struct {
+	Level uint16
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (lsp *LightStatePower) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	if err := binary.Write(buf, order, lsp.Level); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (lsp *LightStatePower) UnmarshalPacket(data io.Reader, order binary.ByteOrder) error {
+	return binary.Read(data, order, &lsp.Level)
+}

--- a/protocol/payloads/lights_test.go
+++ b/protocol/payloads/lights_test.go
@@ -1,0 +1,276 @@
+package lifxpayloads
+
+import (
+	"bytes"
+	"encoding/binary"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+func (*TestSuite) TestLightSetColor_MarshalPacket(c *C) {
+	var packet []byte
+	var err error
+	var u32 uint32
+	var u16 uint16
+	var u8 uint8
+
+	order := binary.LittleEndian
+
+	lsc := &LightSetColor{
+		Reserved: 20,
+		Color: &LightHSBK{
+			Hue:        1,
+			Saturation: 2,
+			Brightness: 3,
+			Kelvin:     4,
+		},
+		Duration: 42 * time.Millisecond,
+	}
+
+	packet, err = lsc.MarshalPacket(order)
+	c.Assert(err, IsNil)
+	c.Assert(packet, NotNil)
+
+	reader := bytes.NewReader(packet)
+
+	// Reserved
+	c.Assert(binary.Read(reader, order, &u8), IsNil)
+	c.Check(u8, Equals, uint8(20))
+
+	// Color.Hue
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(1))
+
+	// Color.Saturation
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(2))
+
+	// Color.Brightness
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(3))
+
+	// Color.Kelvin
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(4))
+
+	// Duration (written as uint32 on the wire)
+	c.Assert(binary.Read(reader, order, &u32), IsNil)
+	c.Check(u32, Equals, uint32(42))
+
+	//
+	// Test that lsc.Duration overflow is handled gracefully
+	//
+	lsc.Duration = (time.Millisecond * time.Duration(^uint32(0))) + 1
+	packet, err = lsc.MarshalPacket(order)
+	c.Assert(err, NotNil)
+	c.Check(packet, IsNil)
+	c.Check(err.Error(), Equals, "LightSetColor.Duration would overflow uint32")
+}
+
+func (*TestSuite) TestLightSetColor_UnmarshalPacket(c *C) {
+	var err error
+	order := binary.LittleEndian
+	buf := &bytes.Buffer{}
+
+	c.Assert(binary.Write(buf, order, uint8(11)), IsNil)  // Reserved
+	c.Assert(binary.Write(buf, order, uint16(22)), IsNil) // Color.Hue
+	c.Assert(binary.Write(buf, order, uint16(33)), IsNil) // Color.Saturation
+	c.Assert(binary.Write(buf, order, uint16(44)), IsNil) // Color.Brightness
+	c.Assert(binary.Write(buf, order, uint16(55)), IsNil) // Color.Kelvin
+	c.Assert(binary.Write(buf, order, uint32(66)), IsNil) // Duration
+
+	lsc := &LightSetColor{}
+
+	err = lsc.UnmarshalPacket(bytes.NewReader(buf.Bytes()), order)
+	c.Assert(err, IsNil)
+	c.Check(lsc.Reserved, Equals, uint8(11))
+	c.Check(lsc.Color.Hue, Equals, uint16(22))
+	c.Check(lsc.Color.Saturation, Equals, uint16(33))
+	c.Check(lsc.Color.Brightness, Equals, uint16(44))
+	c.Check(lsc.Color.Kelvin, Equals, uint16(55))
+	c.Check(lsc.Duration, Equals, 66*time.Millisecond)
+}
+
+func (*TestSuite) TestLightState_MarshalPacket(c *C) {
+	var packet []byte
+	var err error
+	var u64 uint64
+	var u16 uint16
+	var u8 uint8
+
+	order := binary.LittleEndian
+
+	ls := &LightState{
+		Color: &LightHSBK{
+			Hue:        1,
+			Saturation: 2,
+			Brightness: 3,
+			Kelvin:     4,
+		},
+		Reserved:  20,
+		Power:     33,
+		ReservedB: 42,
+	}
+
+	for i := 0; i < 32; i++ {
+		ls.Label[i] = uint8(i + 100)
+	}
+
+	packet, err = ls.MarshalPacket(order)
+	c.Assert(err, IsNil)
+	c.Assert(packet, NotNil)
+
+	reader := bytes.NewReader(packet)
+
+	// Color.Hue
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(1))
+
+	// Color.Saturation
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(2))
+
+	// Color.Brightness
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(3))
+
+	// Color.Kelvin
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(4))
+
+	// Reserved
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(20))
+
+	// Power
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(33))
+
+	// Label
+	for i := 0; i < 32; i++ {
+		c.Assert(binary.Read(reader, order, &u8), IsNil)
+		c.Check(u8, Equals, uint8(i+100))
+	}
+
+	// ReservedB
+	c.Assert(binary.Read(reader, order, &u64), IsNil)
+	c.Check(u64, Equals, uint64(42))
+}
+
+func (*TestSuite) TestLightState_UnmarshalPacket(c *C) {
+	var err error
+	order := binary.LittleEndian
+	buf := &bytes.Buffer{}
+
+	c.Assert(binary.Write(buf, order, uint16(11)), IsNil) // Color.Hue
+	c.Assert(binary.Write(buf, order, uint16(22)), IsNil) // Color.Saturation
+	c.Assert(binary.Write(buf, order, uint16(33)), IsNil) // Color.Brightness
+	c.Assert(binary.Write(buf, order, uint16(44)), IsNil) // Color.Kelvin
+	c.Assert(binary.Write(buf, order, uint16(55)), IsNil) // Reserved
+	c.Assert(binary.Write(buf, order, uint16(66)), IsNil) // Power
+
+	for i := 0; i < 32; i++ {
+		c.Assert(binary.Write(buf, order, uint8(i+100)), IsNil)
+	}
+
+	c.Assert(binary.Write(buf, order, uint64(77)), IsNil) // ReservedB
+
+	ls := &LightState{}
+
+	err = ls.UnmarshalPacket(bytes.NewReader(buf.Bytes()), order)
+	c.Assert(err, IsNil)
+	c.Check(ls.Color.Hue, Equals, uint16(11))
+	c.Check(ls.Color.Saturation, Equals, uint16(22))
+	c.Check(ls.Color.Brightness, Equals, uint16(33))
+	c.Check(ls.Color.Kelvin, Equals, uint16(44))
+	c.Check(ls.Reserved, Equals, uint16(55))
+
+	for i := 0; i < 32; i++ {
+		c.Check(ls.Label[i], Equals, uint8(i+100))
+	}
+
+	c.Check(ls.ReservedB, Equals, uint64(77))
+}
+
+func (*TestSuite) TestLightSetPower_MarshalPacket(c *C) {
+	var packet []byte
+	var err error
+	var u32 uint32
+	var u16 uint16
+
+	order := binary.LittleEndian
+
+	lsp := &LightSetPower{
+		Level:    10,
+		Duration: 42 * time.Millisecond,
+	}
+
+	packet, err = lsp.MarshalPacket(order)
+	c.Assert(err, IsNil)
+	c.Assert(packet, NotNil)
+
+	reader := bytes.NewReader(packet)
+
+	// Level
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(10))
+
+	// Duration (written as uint32 on the wire)
+	c.Assert(binary.Read(reader, order, &u32), IsNil)
+	c.Check(u32, Equals, uint32(42))
+
+	lsp.Duration = (time.Millisecond * time.Duration(^uint32(0))) + 1
+	packet, err = lsp.MarshalPacket(order)
+	c.Assert(err, NotNil)
+	c.Check(packet, IsNil)
+	c.Check(err.Error(), Equals, "LightSetPower.Duration would overflow uint32")
+}
+
+func (*TestSuite) TestLightSetPower_UnmarshalPacket(c *C) {
+	var err error
+	order := binary.LittleEndian
+	buf := &bytes.Buffer{}
+
+	c.Assert(binary.Write(buf, order, uint16(4)), IsNil)  // Level
+	c.Assert(binary.Write(buf, order, uint32(22)), IsNil) // Duration
+
+	lsp := &LightSetPower{}
+	err = lsp.UnmarshalPacket(bytes.NewReader(buf.Bytes()), order)
+	c.Assert(err, IsNil)
+	c.Check(lsp.Level, Equals, uint16(4))
+	c.Check(lsp.Duration, Equals, 22*time.Millisecond)
+}
+
+func (*TestSuite) TestLightStatePower_MarshalPacket(c *C) {
+	var packet []byte
+	var err error
+	var u16 uint16
+
+	order := binary.LittleEndian
+
+	lsp := &LightStatePower{Level: 10}
+
+	packet, err = lsp.MarshalPacket(order)
+	c.Assert(err, IsNil)
+	c.Assert(packet, NotNil)
+
+	reader := bytes.NewReader(packet)
+
+	// Level
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(10))
+}
+
+func (*TestSuite) TestLightStatePower_UnmarshalPacket(c *C) {
+	var err error
+	order := binary.LittleEndian
+	buf := &bytes.Buffer{}
+
+	c.Assert(binary.Write(buf, order, uint16(4)), IsNil) // Level
+
+	lsp := &LightStatePower{}
+	err = lsp.UnmarshalPacket(bytes.NewReader(buf.Bytes()), order)
+	c.Assert(err, IsNil)
+	c.Check(lsp.Level, Equals, uint16(4))
+}


### PR DESCRIPTION
This change adds all of the Light Message payload structs and their Marshaler/Unmarshaler methods.

In addition, this change enables opportunistic testing against `go1.6rc2`. If the 1.6 tests fail, it won't cause the entire build to fail.
