### PR TITLE
add MarshalPacket() and UnmarshalPacket() methods to LightHSBK

### DIFF
--- a/protocol/payloads/lights.go
+++ b/protocol/payloads/lights.go
@@ -41,6 +41,52 @@ type LightHSBK struct {
 	Kelvin uint16
 }
 
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (hsbk *LightHSBK) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	if err := binary.Write(buf, order, hsbk.Hue); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, hsbk.Saturation); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, hsbk.Brightness); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, hsbk.Kelvin); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (hsbk *LightHSBK) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	if err = binary.Read(data, order, &hsbk.Hue); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &hsbk.Saturation); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &hsbk.Brightness); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &hsbk.Kelvin); err != nil {
+		return
+	}
+
+	return
+}
+
 // LightSetColor is the struct representing the payload sent by a client
 // to change the light state.
 //
@@ -77,19 +123,13 @@ func (lsc *LightSetColor) MarshalPacket(order binary.ByteOrder) ([]byte, error) 
 		return nil, err
 	}
 
-	if err := binary.Write(buf, order, lsc.Color.Hue); err != nil {
+	colorPacket, err := lsc.Color.MarshalPacket(order)
+
+	if err != nil {
 		return nil, err
 	}
 
-	if err := binary.Write(buf, order, lsc.Color.Saturation); err != nil {
-		return nil, err
-	}
-
-	if err := binary.Write(buf, order, lsc.Color.Brightness); err != nil {
-		return nil, err
-	}
-
-	if err := binary.Write(buf, order, lsc.Color.Kelvin); err != nil {
+	if _, err := buf.Write(colorPacket); err != nil {
 		return nil, err
 	}
 
@@ -111,19 +151,7 @@ func (lsc *LightSetColor) UnmarshalPacket(data io.Reader, order binary.ByteOrder
 		lsc.Color = &LightHSBK{}
 	}
 
-	if err = binary.Read(data, order, &lsc.Color.Hue); err != nil {
-		return
-	}
-
-	if err = binary.Read(data, order, &lsc.Color.Saturation); err != nil {
-		return
-	}
-
-	if err = binary.Read(data, order, &lsc.Color.Brightness); err != nil {
-		return
-	}
-
-	if err = binary.Read(data, order, &lsc.Color.Kelvin); err != nil {
+	if err = lsc.Color.UnmarshalPacket(data, order); err != nil {
 		return
 	}
 
@@ -162,19 +190,13 @@ func (ls *LightState) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 
 	buf := &bytes.Buffer{}
 
-	if err := binary.Write(buf, order, ls.Color.Hue); err != nil {
+	colorPacket, err := ls.Color.MarshalPacket(order)
+
+	if err != nil {
 		return nil, err
 	}
 
-	if err := binary.Write(buf, order, ls.Color.Saturation); err != nil {
-		return nil, err
-	}
-
-	if err := binary.Write(buf, order, ls.Color.Brightness); err != nil {
-		return nil, err
-	}
-
-	if err := binary.Write(buf, order, ls.Color.Kelvin); err != nil {
+	if _, err := buf.Write(colorPacket); err != nil {
 		return nil, err
 	}
 
@@ -206,19 +228,7 @@ func (ls *LightState) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (e
 		ls.Color = &LightHSBK{}
 	}
 
-	if err = binary.Read(data, order, &ls.Color.Hue); err != nil {
-		return
-	}
-
-	if err = binary.Read(data, order, &ls.Color.Saturation); err != nil {
-		return
-	}
-
-	if err = binary.Read(data, order, &ls.Color.Brightness); err != nil {
-		return
-	}
-
-	if err = binary.Read(data, order, &ls.Color.Kelvin); err != nil {
+	if err = ls.Color.UnmarshalPacket(data, order); err != nil {
 		return
 	}
 

--- a/protocol/payloads/lights_test.go
+++ b/protocol/payloads/lights_test.go
@@ -8,6 +8,63 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+func (*TestSuite) TestLightHSBK_MarshalPacket(c *C) {
+	var packet []byte
+	var err error
+	var u16 uint16
+
+	order := binary.LittleEndian
+
+	hsbk := &LightHSBK{
+		Hue:        1,
+		Saturation: 2,
+		Brightness: 3,
+		Kelvin:     4,
+	}
+
+	packet, err = hsbk.MarshalPacket(order)
+	c.Assert(err, IsNil)
+	c.Assert(packet, NotNil)
+
+	reader := bytes.NewReader(packet)
+
+	// Hue
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(1))
+
+	// Saturation
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(2))
+
+	// Brightness
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(3))
+
+	// Kelvin
+	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(4))
+}
+
+func (*TestSuite) TestLightHSBK_UnmarshalPacket(c *C) {
+	var err error
+	order := binary.LittleEndian
+	buf := &bytes.Buffer{}
+
+	c.Assert(binary.Write(buf, order, uint16(22)), IsNil) // Color.Hue
+	c.Assert(binary.Write(buf, order, uint16(33)), IsNil) // Color.Saturation
+	c.Assert(binary.Write(buf, order, uint16(44)), IsNil) // Color.Brightness
+	c.Assert(binary.Write(buf, order, uint16(55)), IsNil) // Color.Kelvin
+
+	hsbk := &LightHSBK{}
+
+	err = hsbk.UnmarshalPacket(bytes.NewReader(buf.Bytes()), order)
+	c.Assert(err, IsNil)
+	c.Check(hsbk.Hue, Equals, uint16(22))
+	c.Check(hsbk.Saturation, Equals, uint16(33))
+	c.Check(hsbk.Brightness, Equals, uint16(44))
+	c.Check(hsbk.Kelvin, Equals, uint16(55))
+}
+
 func (*TestSuite) TestLightSetColor_MarshalPacket(c *C) {
 	var packet []byte
 	var err error


### PR DESCRIPTION
To remove some duplicated code, we need to add `MarshalPacket()` and `UnmarshalPacket()` methods to `*LightHSBK`. Things that use that struct now use the new methods instead of marshaling the values directly.
