### PR TITLE
make tests more DRY by removing binary.LittleEndian references

### DIFF
--- a/protocol/frame_address_test.go
+++ b/protocol/frame_address_test.go
@@ -35,7 +35,7 @@ func (t *TestSuite) TestFrameAddress_MarshalPacket(c *C) {
 		Sequence:      42,
 	}
 
-	packet, err = fraddr.MarshalPacket(binary.LittleEndian)
+	packet, err = fraddr.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 	c.Check(len(packet), Equals, FrameAddressByteSize)
@@ -43,26 +43,26 @@ func (t *TestSuite) TestFrameAddress_MarshalPacket(c *C) {
 	reader := bytes.NewReader(packet)
 
 	// Read the target field
-	err = binary.Read(reader, binary.LittleEndian, &u64)
+	err = binary.Read(reader, t.order, &u64)
 	c.Assert(err, IsNil)
 	c.Check(u64, Equals, uint64(0))
 
 	// Read the 6 reserved uint8 blocks
 	for i := 0; i < 6; i++ {
-		err = binary.Read(reader, binary.LittleEndian, &u8)
+		err = binary.Read(reader, t.order, &u8)
 		c.Assert(err, IsNil)
 		c.Check(u8, Equals, uint8(0))
 	}
 
 	// Read the single uint8 reserved block
-	err = binary.Read(reader, binary.LittleEndian, &u8)
+	err = binary.Read(reader, t.order, &u8)
 	c.Assert(err, IsNil)
 	c.Check(u8>>2, Equals, uint8(10))
 	c.Check(u8>>1&1, Equals, uint8(0))
 	c.Check(u8&1, Equals, uint8(1))
 
 	// Read the sequence field
-	err = binary.Read(reader, binary.LittleEndian, &u8)
+	err = binary.Read(reader, t.order, &u8)
 	c.Assert(err, IsNil)
 	c.Check(u8, Equals, uint8(42))
 
@@ -78,7 +78,7 @@ func (t *TestSuite) TestFrameAddress_MarshalPacket(c *C) {
 		Sequence:      22,
 	}
 
-	packet, err = fraddr.MarshalPacket(binary.LittleEndian)
+	packet, err = fraddr.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 	c.Check(len(packet), Equals, FrameAddressByteSize)
@@ -86,26 +86,26 @@ func (t *TestSuite) TestFrameAddress_MarshalPacket(c *C) {
 	reader = bytes.NewReader(packet)
 
 	// Read the target field
-	err = binary.Read(reader, binary.LittleEndian, &u64)
+	err = binary.Read(reader, t.order, &u64)
 	c.Assert(err, IsNil)
 	c.Check(u64, Equals, uint64(2351197419751440384))
 
 	// Read the 6 reserved uint8 blocks
 	for i := 0; i < 6; i++ {
-		err = binary.Read(reader, binary.LittleEndian, &u8)
+		err = binary.Read(reader, t.order, &u8)
 		c.Assert(err, IsNil)
 		c.Check(u8, Equals, uint8(i+1))
 	}
 
 	// Read the single uint8 reserved block
-	err = binary.Read(reader, binary.LittleEndian, &u8)
+	err = binary.Read(reader, t.order, &u8)
 	c.Assert(err, IsNil)
 	c.Check(u8>>2, Equals, uint8(11))
 	c.Check(u8>>1&1, Equals, uint8(1))
 	c.Check(u8&1, Equals, uint8(0))
 
 	// Read the sequence field
-	err = binary.Read(reader, binary.LittleEndian, &u8)
+	err = binary.Read(reader, t.order, &u8)
 	c.Assert(err, IsNil)
 	c.Check(u8, Equals, uint8(22))
 }
@@ -124,19 +124,19 @@ func (t *TestSuite) TestFrameAddress_UnmarshalPacket(c *C) {
 		uint64(50)<<23 |
 		uint64(51)<<15
 
-	err = binary.Write(buf, binary.LittleEndian, u64)
+	err = binary.Write(buf, t.order, u64)
 	c.Assert(err, IsNil)
 
 	for i := 0; i < 6; i++ {
-		err = binary.Write(buf, binary.LittleEndian, uint8(i))
+		err = binary.Write(buf, t.order, uint8(i))
 		c.Assert(err, IsNil)
 	}
 
 	u8 = 20<<2 | 1<<1 | 1&1
-	err = binary.Write(buf, binary.LittleEndian, u8)
+	err = binary.Write(buf, t.order, u8)
 	c.Assert(err, IsNil)
 
-	err = binary.Write(buf, binary.LittleEndian, uint8(42))
+	err = binary.Write(buf, t.order, uint8(42))
 	c.Assert(err, IsNil)
 
 	//
@@ -144,7 +144,7 @@ func (t *TestSuite) TestFrameAddress_UnmarshalPacket(c *C) {
 	//
 	fra := &FrameAddress{}
 
-	err = fra.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	err = fra.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 	c.Assert(len(fra.Target), Equals, 6)
 	c.Check(fra.Target[0], Equals, byte(65))
@@ -173,19 +173,19 @@ func (t *TestSuite) TestFrameAddress_UnmarshalPacket(c *C) {
 		uint64(50)<<23 |
 		uint64(51)<<15
 
-	err = binary.Write(buf, binary.LittleEndian, u64)
+	err = binary.Write(buf, t.order, u64)
 	c.Assert(err, IsNil)
 
 	for i := 0; i < 6; i++ {
-		err = binary.Write(buf, binary.LittleEndian, uint8(i+1))
+		err = binary.Write(buf, t.order, uint8(i+1))
 		c.Assert(err, IsNil)
 	}
 
 	u8 = 20<<2 | 0<<1 | 0&1
-	err = binary.Write(buf, binary.LittleEndian, u8)
+	err = binary.Write(buf, t.order, u8)
 	c.Assert(err, IsNil)
 
-	err = binary.Write(buf, binary.LittleEndian, uint8(42))
+	err = binary.Write(buf, t.order, uint8(42))
 	c.Assert(err, IsNil)
 
 	//
@@ -193,7 +193,7 @@ func (t *TestSuite) TestFrameAddress_UnmarshalPacket(c *C) {
 	//
 	fra = &FrameAddress{}
 
-	err = fra.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	err = fra.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 	c.Assert(len(fra.Target), Equals, 6)
 	c.Check(fra.Target[0], Equals, byte(65))

--- a/protocol/frame_test.go
+++ b/protocol/frame_test.go
@@ -38,7 +38,7 @@ func (t *TestSuite) TestFrame_MarshalPacket(c *C) {
 		Source:      42,
 	}
 
-	packet, err = frame.MarshalPacket(binary.LittleEndian)
+	packet, err = frame.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 	c.Check(len(packet), Equals, FrameByteSize)
@@ -46,12 +46,12 @@ func (t *TestSuite) TestFrame_MarshalPacket(c *C) {
 	reader := bytes.NewReader(packet)
 
 	// Read the size field
-	err = binary.Read(reader, binary.LittleEndian, &u16)
+	err = binary.Read(reader, t.order, &u16)
 	c.Assert(err, IsNil)
 	c.Check(u16, Equals, uint16(8))
 
 	// Read the middle fields that are joined together
-	err = binary.Read(reader, binary.LittleEndian, &u16)
+	err = binary.Read(reader, t.order, &u16)
 	c.Assert(err, IsNil)
 	c.Check(uint8(u16>>14), Equals, uint8(2)) // Origin
 	c.Check(u16>>13&1, Equals, uint16(1))     // Tagged
@@ -59,7 +59,7 @@ func (t *TestSuite) TestFrame_MarshalPacket(c *C) {
 	c.Check(u16<<4>>4, Equals, uint16(1024))  // Protocol
 
 	// Read the Source field
-	err = binary.Read(reader, binary.LittleEndian, &u32)
+	err = binary.Read(reader, t.order, &u32)
 	c.Assert(err, IsNil)
 	c.Check(u32, Equals, uint32(42))
 
@@ -75,7 +75,7 @@ func (t *TestSuite) TestFrame_MarshalPacket(c *C) {
 		Source:      4242,
 	}
 
-	packet, err = frame.MarshalPacket(binary.LittleEndian)
+	packet, err = frame.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 	c.Check(len(packet), Equals, FrameByteSize)
@@ -83,12 +83,12 @@ func (t *TestSuite) TestFrame_MarshalPacket(c *C) {
 	reader = bytes.NewReader(packet)
 
 	// Read the size field
-	err = binary.Read(reader, binary.LittleEndian, &u16)
+	err = binary.Read(reader, t.order, &u16)
 	c.Assert(err, IsNil)
 	c.Check(u16, Equals, uint16(10))
 
 	// Read the middle fields that are joined together
-	err = binary.Read(reader, binary.LittleEndian, &u16)
+	err = binary.Read(reader, t.order, &u16)
 	c.Assert(err, IsNil)
 	c.Check(uint8(u16>>14), Equals, uint8(0)) // Origin
 	c.Check(u16>>13&1, Equals, uint16(0))     // Tagged
@@ -96,7 +96,7 @@ func (t *TestSuite) TestFrame_MarshalPacket(c *C) {
 	c.Check(u16<<4>>4, Equals, uint16(4095))  // Protocol
 
 	// Read the Source field
-	err = binary.Read(reader, binary.LittleEndian, &u32)
+	err = binary.Read(reader, t.order, &u32)
 	c.Assert(err, IsNil)
 	c.Check(u32, Equals, uint32(4242))
 
@@ -112,7 +112,7 @@ func (t *TestSuite) TestFrame_MarshalPacket(c *C) {
 		Source:      42,
 	}
 
-	packet, err = frame.MarshalPacket(binary.LittleEndian)
+	packet, err = frame.MarshalPacket(t.order)
 	c.Check(err, Equals, ErrFrameOriginOverflow)
 	c.Check(packet, IsNil)
 
@@ -128,7 +128,7 @@ func (t *TestSuite) TestFrame_MarshalPacket(c *C) {
 		Source:      42,
 	}
 
-	packet, err = frame.MarshalPacket(binary.LittleEndian)
+	packet, err = frame.MarshalPacket(t.order)
 	c.Check(err, Equals, ErrFrameProtocolOverflow)
 	c.Check(packet, IsNil)
 }
@@ -147,16 +147,16 @@ func (t *TestSuite) TestFrame_UnmarshalPacket(c *C) {
 		protocol<<4>>4
 
 	buf := new(bytes.Buffer)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint16(8)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, u16), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(42)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint16(8)), IsNil)
+	c.Assert(binary.Write(buf, t.order, u16), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint32(42)), IsNil)
 
 	//
 	// Test that Unmarshaling works
 	//
 	frame := &Frame{}
 
-	err = frame.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	err = frame.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 
 	c.Check(frame.Size, Equals, uint16(8))
@@ -177,16 +177,16 @@ func (t *TestSuite) TestFrame_UnmarshalPacket(c *C) {
 		protocol<<4>>4
 
 	buf = new(bytes.Buffer)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint16(10)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, u16), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(4242)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint16(10)), IsNil)
+	c.Assert(binary.Write(buf, t.order, u16), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint32(4242)), IsNil)
 
 	//
 	// Test that Unmarshaling works with some adjusted fields
 	//
 	frame = &Frame{}
 
-	err = frame.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	err = frame.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 
 	c.Check(frame.Size, Equals, uint16(10))

--- a/protocol/header_test.go
+++ b/protocol/header_test.go
@@ -11,7 +11,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (*TestSuite) TestHeader_MarshalPacket(c *C) {
+func (t *TestSuite) TestHeader_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
 	var u64 uint64
@@ -49,19 +49,19 @@ func (*TestSuite) TestHeader_MarshalPacket(c *C) {
 		ProtocolHeader: ph,
 	}
 
-	packet, err = header.MarshalPacket(binary.LittleEndian)
+	packet, err = header.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 
 	reader := bytes.NewReader(packet)
 
 	// Read the size field
-	err = binary.Read(reader, binary.LittleEndian, &u16)
+	err = binary.Read(reader, t.order, &u16)
 	c.Assert(err, IsNil)
 	c.Check(u16, Equals, uint16(8))
 
 	// Read the middle fields that are joined together
-	err = binary.Read(reader, binary.LittleEndian, &u16)
+	err = binary.Read(reader, t.order, &u16)
 	c.Assert(err, IsNil)
 	c.Check(uint8(u16>>14), Equals, uint8(2)) // Origin
 	c.Check(u16>>13&1, Equals, uint16(1))     // Tagged
@@ -69,51 +69,51 @@ func (*TestSuite) TestHeader_MarshalPacket(c *C) {
 	c.Check(u16<<4>>4, Equals, uint16(1024))  // Protocol
 
 	// Read the Source field
-	err = binary.Read(reader, binary.LittleEndian, &u32)
+	err = binary.Read(reader, t.order, &u32)
 	c.Assert(err, IsNil)
 	c.Check(u32, Equals, uint32(42))
 
 	// Read the target field
-	err = binary.Read(reader, binary.LittleEndian, &u64)
+	err = binary.Read(reader, t.order, &u64)
 	c.Assert(err, IsNil)
 	c.Check(u64, Equals, uint64(0))
 
 	// Read the 6 reserved uint8 blocks
 	for i := 0; i < 6; i++ {
-		err = binary.Read(reader, binary.LittleEndian, &u8)
+		err = binary.Read(reader, t.order, &u8)
 		c.Assert(err, IsNil)
 		c.Check(u8, Equals, uint8(0))
 	}
 
 	// Read the single uint8 reserved block
-	err = binary.Read(reader, binary.LittleEndian, &u8)
+	err = binary.Read(reader, t.order, &u8)
 	c.Assert(err, IsNil)
 	c.Check(u8>>2, Equals, uint8(10))
 	c.Check(u8>>1&1, Equals, uint8(0))
 	c.Check(u8&1, Equals, uint8(1))
 
 	// Read the sequence field
-	err = binary.Read(reader, binary.LittleEndian, &u8)
+	err = binary.Read(reader, t.order, &u8)
 	c.Assert(err, IsNil)
 	c.Check(u8, Equals, uint8(42))
 
 	// read the first reserved block
-	err = binary.Read(reader, binary.LittleEndian, &u64)
+	err = binary.Read(reader, t.order, &u64)
 	c.Assert(err, IsNil)
 	c.Check(u64, Equals, uint64(1))
 
 	// read the type field
-	err = binary.Read(reader, binary.LittleEndian, &u16)
+	err = binary.Read(reader, t.order, &u16)
 	c.Assert(err, IsNil)
 	c.Check(u16, Equals, uint16(2))
 
 	// read the second reserved block
-	err = binary.Read(reader, binary.LittleEndian, &u16)
+	err = binary.Read(reader, t.order, &u16)
 	c.Assert(err, IsNil)
 	c.Check(u16, Equals, uint16(3))
 }
 
-func (*TestSuite) TestHeader_UnmarshalPacket(c *C) {
+func (t *TestSuite) TestHeader_UnmarshalPacket(c *C) {
 	var err error
 	var u64 uint64
 	var u8 uint8
@@ -129,9 +129,9 @@ func (*TestSuite) TestHeader_UnmarshalPacket(c *C) {
 		protocol<<4>>4
 
 	buf := &bytes.Buffer{}
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint16(8)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, u16), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(42)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint16(8)), IsNil)
+	c.Assert(binary.Write(buf, t.order, u16), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint32(42)), IsNil)
 
 	u64 = uint64(65)<<55 |
 		uint64(66)<<47 |
@@ -140,18 +140,18 @@ func (*TestSuite) TestHeader_UnmarshalPacket(c *C) {
 		uint64(50)<<23 |
 		uint64(51)<<15
 
-	c.Assert(binary.Write(buf, binary.LittleEndian, u64), IsNil)
+	c.Assert(binary.Write(buf, t.order, u64), IsNil)
 
 	for i := 0; i < 6; i++ {
-		c.Assert(binary.Write(buf, binary.LittleEndian, uint8(i)), IsNil)
+		c.Assert(binary.Write(buf, t.order, uint8(i)), IsNil)
 	}
 
 	u8 = 20<<2 | 1<<1 | 1&1
-	c.Assert(binary.Write(buf, binary.LittleEndian, u8), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint8(42)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(3)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint16(1)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(2)), IsNil)
+	c.Assert(binary.Write(buf, t.order, u8), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint8(42)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint64(3)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint16(1)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint64(2)), IsNil)
 
 	frame := &Frame{}
 	fra := &FrameAddress{}
@@ -163,7 +163,7 @@ func (*TestSuite) TestHeader_UnmarshalPacket(c *C) {
 		ProtocolHeader: ph,
 	}
 
-	err = header.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	err = header.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 
 	c.Check(frame.Size, Equals, uint16(8))

--- a/protocol/payloads/device_test.go
+++ b/protocol/payloads/device_test.go
@@ -11,7 +11,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (*TestSuite) TestDeviceStateService_MarshalPacket(c *C) {
+func (t *TestSuite) TestDeviceStateService_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
 	var u32 uint32
@@ -22,36 +22,36 @@ func (*TestSuite) TestDeviceStateService_MarshalPacket(c *C) {
 		Port:    56700,
 	}
 
-	packet, err = dss.MarshalPacket(binary.LittleEndian)
+	packet, err = dss.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 	c.Assert(len(packet), Equals, 5)
 
 	reader := bytes.NewReader(packet)
 
-	c.Assert(binary.Read(reader, binary.LittleEndian, &u8), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u8), IsNil)
 	c.Check(u8, Equals, uint8(1))
-	c.Assert(binary.Read(reader, binary.LittleEndian, &u32), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u32), IsNil)
 	c.Check(u32, Equals, uint32(56700))
 }
 
-func (*TestSuite) TestDeviceStateService_UnmarshalPacket(c *C) {
+func (t *TestSuite) TestDeviceStateService_UnmarshalPacket(c *C) {
 	var err error
 
 	buf := &bytes.Buffer{}
 
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint8(42)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(8484)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint8(42)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint32(8484)), IsNil)
 
 	dss := &DeviceStateService{}
 
-	err = dss.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	err = dss.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 	c.Check(dss.Service, Equals, uint8(42))
 	c.Check(dss.Port, Equals, uint32(8484))
 }
 
-func (*TestSuite) TestDeviceStateHostInfo_MarshalPacket(c *C) {
+func (t *TestSuite) TestDeviceStateHostInfo_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
 	var f32 float32
@@ -65,39 +65,39 @@ func (*TestSuite) TestDeviceStateHostInfo_MarshalPacket(c *C) {
 		Reserved: 99,
 	}
 
-	packet, err = dshi.MarshalPacket(binary.LittleEndian)
+	packet, err = dshi.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 	c.Assert(len(packet), Equals, 14)
 
 	reader := bytes.NewReader(packet)
 
-	c.Assert(binary.Read(reader, binary.LittleEndian, &f32), IsNil)
+	c.Assert(binary.Read(reader, t.order, &f32), IsNil)
 	c.Check(f32, Equals, float32(42.0))
 
-	c.Assert(binary.Read(reader, binary.LittleEndian, &u32), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u32), IsNil)
 	c.Check(u32, Equals, uint32(22))
 
-	c.Assert(binary.Read(reader, binary.LittleEndian, &u32), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u32), IsNil)
 	c.Check(u32, Equals, uint32(44))
 
-	c.Assert(binary.Read(reader, binary.LittleEndian, &i16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &i16), IsNil)
 	c.Check(i16, Equals, int16(99))
 }
 
-func (*TestSuite) TestDeviceStateHostInfo_UnmarshalPacket(c *C) {
+func (t *TestSuite) TestDeviceStateHostInfo_UnmarshalPacket(c *C) {
 	var err error
 
 	buf := &bytes.Buffer{}
 
-	c.Assert(binary.Write(buf, binary.LittleEndian, float32(88)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(55)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(77)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, int16(66)), IsNil)
+	c.Assert(binary.Write(buf, t.order, float32(88)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint32(55)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint32(77)), IsNil)
+	c.Assert(binary.Write(buf, t.order, int16(66)), IsNil)
 
 	dshi := &DeviceStateHostInfo{}
 
-	err = dshi.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	err = dshi.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 	c.Check(dshi.Signal, Equals, float32(88))
 	c.Check(dshi.Tx, Equals, uint32(55))
@@ -105,7 +105,7 @@ func (*TestSuite) TestDeviceStateHostInfo_UnmarshalPacket(c *C) {
 	c.Check(dshi.Reserved, Equals, int16(66))
 }
 
-func (*TestSuite) TestDeviceStateHostFirmware_MarshalPacket(c *C) {
+func (t *TestSuite) TestDeviceStateHostFirmware_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
 	var u64 uint64
@@ -117,42 +117,42 @@ func (*TestSuite) TestDeviceStateHostFirmware_MarshalPacket(c *C) {
 		Version:  200,
 	}
 
-	packet, err = dshf.MarshalPacket(binary.LittleEndian)
+	packet, err = dshf.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 	c.Assert(len(packet), Equals, 20)
 
 	reader := bytes.NewReader(packet)
 
-	c.Assert(binary.Read(reader, binary.LittleEndian, &u64), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u64), IsNil)
 	c.Check(u64, Equals, uint64(100))
 
-	c.Assert(binary.Read(reader, binary.LittleEndian, &u64), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u64), IsNil)
 	c.Check(u64, Equals, uint64(30))
 
-	c.Assert(binary.Read(reader, binary.LittleEndian, &u32), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u32), IsNil)
 	c.Check(u32, Equals, uint32(200))
 }
 
-func (*TestSuite) TestDeviceStateHostFirmware_UnmarshalPacket(c *C) {
+func (t *TestSuite) TestDeviceStateHostFirmware_UnmarshalPacket(c *C) {
 	var err error
 
 	buf := &bytes.Buffer{}
 
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(42)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(84)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(99)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint64(42)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint64(84)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint32(99)), IsNil)
 
 	dshf := &DeviceStateHostFirmware{}
 
-	err = dshf.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	err = dshf.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 	c.Check(dshf.Build, Equals, uint64(42))
 	c.Check(dshf.Reserved, Equals, uint64(84))
 	c.Check(dshf.Version, Equals, uint32(99))
 }
 
-func (*TestSuite) TestDeviceStateWifiInfo_MarshalPacket(c *C) {
+func (t *TestSuite) TestDeviceStateWifiInfo_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
 	var f32 float32
@@ -166,39 +166,39 @@ func (*TestSuite) TestDeviceStateWifiInfo_MarshalPacket(c *C) {
 		Reserved: 99,
 	}
 
-	packet, err = dswi.MarshalPacket(binary.LittleEndian)
+	packet, err = dswi.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 	c.Assert(len(packet), Equals, 14)
 
 	reader := bytes.NewReader(packet)
 
-	c.Assert(binary.Read(reader, binary.LittleEndian, &f32), IsNil)
+	c.Assert(binary.Read(reader, t.order, &f32), IsNil)
 	c.Check(f32, Equals, float32(42.0))
 
-	c.Assert(binary.Read(reader, binary.LittleEndian, &u32), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u32), IsNil)
 	c.Check(u32, Equals, uint32(22))
 
-	c.Assert(binary.Read(reader, binary.LittleEndian, &u32), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u32), IsNil)
 	c.Check(u32, Equals, uint32(44))
 
-	c.Assert(binary.Read(reader, binary.LittleEndian, &i16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &i16), IsNil)
 	c.Check(i16, Equals, int16(99))
 }
 
-func (*TestSuite) TestDeviceStateWifiInfo_UnmarshalPacket(c *C) {
+func (t *TestSuite) TestDeviceStateWifiInfo_UnmarshalPacket(c *C) {
 	var err error
 
 	buf := &bytes.Buffer{}
 
-	c.Assert(binary.Write(buf, binary.LittleEndian, float32(88)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(55)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(77)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, int16(66)), IsNil)
+	c.Assert(binary.Write(buf, t.order, float32(88)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint32(55)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint32(77)), IsNil)
+	c.Assert(binary.Write(buf, t.order, int16(66)), IsNil)
 
 	dswi := &DeviceStateWifiInfo{}
 
-	err = dswi.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	err = dswi.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 	c.Check(dswi.Signal, Equals, float32(88))
 	c.Check(dswi.Tx, Equals, uint32(55))
@@ -206,7 +206,7 @@ func (*TestSuite) TestDeviceStateWifiInfo_UnmarshalPacket(c *C) {
 	c.Check(dswi.Reserved, Equals, int16(66))
 }
 
-func (*TestSuite) TestDeviceStateWifiFirmware_MarshalPacket(c *C) {
+func (t *TestSuite) TestDeviceStateWifiFirmware_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
 	var u64 uint64
@@ -218,35 +218,35 @@ func (*TestSuite) TestDeviceStateWifiFirmware_MarshalPacket(c *C) {
 		Version:  200,
 	}
 
-	packet, err = dswf.MarshalPacket(binary.LittleEndian)
+	packet, err = dswf.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 	c.Assert(len(packet), Equals, 20)
 
 	reader := bytes.NewReader(packet)
 
-	c.Assert(binary.Read(reader, binary.LittleEndian, &u64), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u64), IsNil)
 	c.Check(u64, Equals, uint64(100))
 
-	c.Assert(binary.Read(reader, binary.LittleEndian, &u64), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u64), IsNil)
 	c.Check(u64, Equals, uint64(30))
 
-	c.Assert(binary.Read(reader, binary.LittleEndian, &u32), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u32), IsNil)
 	c.Check(u32, Equals, uint32(200))
 }
 
-func (*TestSuite) TestDeviceStateWifiFirmware_UnmarshalPacket(c *C) {
+func (t *TestSuite) TestDeviceStateWifiFirmware_UnmarshalPacket(c *C) {
 	var err error
 
 	buf := &bytes.Buffer{}
 
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(42)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(84)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint32(99)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint64(42)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint64(84)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint32(99)), IsNil)
 
 	dswf := &DeviceStateWifiFirmware{}
 
-	err = dswf.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	err = dswf.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 	c.Check(dswf.Build, Equals, uint64(42))
 	c.Check(dswf.Reserved, Equals, uint64(84))

--- a/protocol/payloads/lights_test.go
+++ b/protocol/payloads/lights_test.go
@@ -8,12 +8,10 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (*TestSuite) TestLightHSBK_MarshalPacket(c *C) {
+func (t *TestSuite) TestLightHSBK_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
 	var u16 uint16
-
-	order := binary.LittleEndian
 
 	hsbk := &LightHSBK{
 		Hue:        1,
@@ -22,42 +20,41 @@ func (*TestSuite) TestLightHSBK_MarshalPacket(c *C) {
 		Kelvin:     4,
 	}
 
-	packet, err = hsbk.MarshalPacket(order)
+	packet, err = hsbk.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 
 	reader := bytes.NewReader(packet)
 
 	// Hue
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(1))
 
 	// Saturation
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(2))
 
 	// Brightness
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(3))
 
 	// Kelvin
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(4))
 }
 
-func (*TestSuite) TestLightHSBK_UnmarshalPacket(c *C) {
+func (t *TestSuite) TestLightHSBK_UnmarshalPacket(c *C) {
 	var err error
-	order := binary.LittleEndian
 	buf := &bytes.Buffer{}
 
-	c.Assert(binary.Write(buf, order, uint16(22)), IsNil) // Color.Hue
-	c.Assert(binary.Write(buf, order, uint16(33)), IsNil) // Color.Saturation
-	c.Assert(binary.Write(buf, order, uint16(44)), IsNil) // Color.Brightness
-	c.Assert(binary.Write(buf, order, uint16(55)), IsNil) // Color.Kelvin
+	c.Assert(binary.Write(buf, t.order, uint16(22)), IsNil) // Color.Hue
+	c.Assert(binary.Write(buf, t.order, uint16(33)), IsNil) // Color.Saturation
+	c.Assert(binary.Write(buf, t.order, uint16(44)), IsNil) // Color.Brightness
+	c.Assert(binary.Write(buf, t.order, uint16(55)), IsNil) // Color.Kelvin
 
 	hsbk := &LightHSBK{}
 
-	err = hsbk.UnmarshalPacket(bytes.NewReader(buf.Bytes()), order)
+	err = hsbk.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 	c.Check(hsbk.Hue, Equals, uint16(22))
 	c.Check(hsbk.Saturation, Equals, uint16(33))
@@ -65,14 +62,12 @@ func (*TestSuite) TestLightHSBK_UnmarshalPacket(c *C) {
 	c.Check(hsbk.Kelvin, Equals, uint16(55))
 }
 
-func (*TestSuite) TestLightSetColor_MarshalPacket(c *C) {
+func (t *TestSuite) TestLightSetColor_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
 	var u32 uint32
 	var u16 uint16
 	var u8 uint8
-
-	order := binary.LittleEndian
 
 	lsc := &LightSetColor{
 		Reserved: 20,
@@ -85,61 +80,60 @@ func (*TestSuite) TestLightSetColor_MarshalPacket(c *C) {
 		Duration: 42 * time.Millisecond,
 	}
 
-	packet, err = lsc.MarshalPacket(order)
+	packet, err = lsc.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 
 	reader := bytes.NewReader(packet)
 
 	// Reserved
-	c.Assert(binary.Read(reader, order, &u8), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u8), IsNil)
 	c.Check(u8, Equals, uint8(20))
 
 	// Color.Hue
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(1))
 
 	// Color.Saturation
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(2))
 
 	// Color.Brightness
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(3))
 
 	// Color.Kelvin
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(4))
 
 	// Duration (written as uint32 on the wire)
-	c.Assert(binary.Read(reader, order, &u32), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u32), IsNil)
 	c.Check(u32, Equals, uint32(42))
 
 	//
 	// Test that lsc.Duration overflow is handled gracefully
 	//
 	lsc.Duration = (time.Millisecond * time.Duration(^uint32(0))) + 1
-	packet, err = lsc.MarshalPacket(order)
+	packet, err = lsc.MarshalPacket(t.order)
 	c.Assert(err, NotNil)
 	c.Check(packet, IsNil)
 	c.Check(err.Error(), Equals, "LightSetColor.Duration would overflow uint32")
 }
 
-func (*TestSuite) TestLightSetColor_UnmarshalPacket(c *C) {
+func (t *TestSuite) TestLightSetColor_UnmarshalPacket(c *C) {
 	var err error
-	order := binary.LittleEndian
 	buf := &bytes.Buffer{}
 
-	c.Assert(binary.Write(buf, order, uint8(11)), IsNil)  // Reserved
-	c.Assert(binary.Write(buf, order, uint16(22)), IsNil) // Color.Hue
-	c.Assert(binary.Write(buf, order, uint16(33)), IsNil) // Color.Saturation
-	c.Assert(binary.Write(buf, order, uint16(44)), IsNil) // Color.Brightness
-	c.Assert(binary.Write(buf, order, uint16(55)), IsNil) // Color.Kelvin
-	c.Assert(binary.Write(buf, order, uint32(66)), IsNil) // Duration
+	c.Assert(binary.Write(buf, t.order, uint8(11)), IsNil)  // Reserved
+	c.Assert(binary.Write(buf, t.order, uint16(22)), IsNil) // Color.Hue
+	c.Assert(binary.Write(buf, t.order, uint16(33)), IsNil) // Color.Saturation
+	c.Assert(binary.Write(buf, t.order, uint16(44)), IsNil) // Color.Brightness
+	c.Assert(binary.Write(buf, t.order, uint16(55)), IsNil) // Color.Kelvin
+	c.Assert(binary.Write(buf, t.order, uint32(66)), IsNil) // Duration
 
 	lsc := &LightSetColor{}
 
-	err = lsc.UnmarshalPacket(bytes.NewReader(buf.Bytes()), order)
+	err = lsc.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 	c.Check(lsc.Reserved, Equals, uint8(11))
 	c.Check(lsc.Color.Hue, Equals, uint16(22))
@@ -149,14 +143,12 @@ func (*TestSuite) TestLightSetColor_UnmarshalPacket(c *C) {
 	c.Check(lsc.Duration, Equals, 66*time.Millisecond)
 }
 
-func (*TestSuite) TestLightState_MarshalPacket(c *C) {
+func (t *TestSuite) TestLightState_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
 	var u64 uint64
 	var u16 uint16
 	var u8 uint8
-
-	order := binary.LittleEndian
 
 	ls := &LightState{
 		Color: &LightHSBK{
@@ -174,68 +166,67 @@ func (*TestSuite) TestLightState_MarshalPacket(c *C) {
 		ls.Label[i] = uint8(i + 100)
 	}
 
-	packet, err = ls.MarshalPacket(order)
+	packet, err = ls.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 
 	reader := bytes.NewReader(packet)
 
 	// Color.Hue
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(1))
 
 	// Color.Saturation
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(2))
 
 	// Color.Brightness
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(3))
 
 	// Color.Kelvin
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(4))
 
 	// Reserved
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(20))
 
 	// Power
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(33))
 
 	// Label
 	for i := 0; i < 32; i++ {
-		c.Assert(binary.Read(reader, order, &u8), IsNil)
+		c.Assert(binary.Read(reader, t.order, &u8), IsNil)
 		c.Check(u8, Equals, uint8(i+100))
 	}
 
 	// ReservedB
-	c.Assert(binary.Read(reader, order, &u64), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u64), IsNil)
 	c.Check(u64, Equals, uint64(42))
 }
 
-func (*TestSuite) TestLightState_UnmarshalPacket(c *C) {
+func (t *TestSuite) TestLightState_UnmarshalPacket(c *C) {
 	var err error
-	order := binary.LittleEndian
 	buf := &bytes.Buffer{}
 
-	c.Assert(binary.Write(buf, order, uint16(11)), IsNil) // Color.Hue
-	c.Assert(binary.Write(buf, order, uint16(22)), IsNil) // Color.Saturation
-	c.Assert(binary.Write(buf, order, uint16(33)), IsNil) // Color.Brightness
-	c.Assert(binary.Write(buf, order, uint16(44)), IsNil) // Color.Kelvin
-	c.Assert(binary.Write(buf, order, uint16(55)), IsNil) // Reserved
-	c.Assert(binary.Write(buf, order, uint16(66)), IsNil) // Power
+	c.Assert(binary.Write(buf, t.order, uint16(11)), IsNil) // Color.Hue
+	c.Assert(binary.Write(buf, t.order, uint16(22)), IsNil) // Color.Saturation
+	c.Assert(binary.Write(buf, t.order, uint16(33)), IsNil) // Color.Brightness
+	c.Assert(binary.Write(buf, t.order, uint16(44)), IsNil) // Color.Kelvin
+	c.Assert(binary.Write(buf, t.order, uint16(55)), IsNil) // Reserved
+	c.Assert(binary.Write(buf, t.order, uint16(66)), IsNil) // Power
 
 	for i := 0; i < 32; i++ {
-		c.Assert(binary.Write(buf, order, uint8(i+100)), IsNil)
+		c.Assert(binary.Write(buf, t.order, uint8(i+100)), IsNil)
 	}
 
-	c.Assert(binary.Write(buf, order, uint64(77)), IsNil) // ReservedB
+	c.Assert(binary.Write(buf, t.order, uint64(77)), IsNil) // ReservedB
 
 	ls := &LightState{}
 
-	err = ls.UnmarshalPacket(bytes.NewReader(buf.Bytes()), order)
+	err = ls.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 	c.Check(ls.Color.Hue, Equals, uint16(11))
 	c.Check(ls.Color.Saturation, Equals, uint16(22))
@@ -250,84 +241,78 @@ func (*TestSuite) TestLightState_UnmarshalPacket(c *C) {
 	c.Check(ls.ReservedB, Equals, uint64(77))
 }
 
-func (*TestSuite) TestLightSetPower_MarshalPacket(c *C) {
+func (t *TestSuite) TestLightSetPower_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
 	var u32 uint32
 	var u16 uint16
-
-	order := binary.LittleEndian
 
 	lsp := &LightSetPower{
 		Level:    10,
 		Duration: 42 * time.Millisecond,
 	}
 
-	packet, err = lsp.MarshalPacket(order)
+	packet, err = lsp.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 
 	reader := bytes.NewReader(packet)
 
 	// Level
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(10))
 
 	// Duration (written as uint32 on the wire)
-	c.Assert(binary.Read(reader, order, &u32), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u32), IsNil)
 	c.Check(u32, Equals, uint32(42))
 
 	lsp.Duration = (time.Millisecond * time.Duration(^uint32(0))) + 1
-	packet, err = lsp.MarshalPacket(order)
+	packet, err = lsp.MarshalPacket(t.order)
 	c.Assert(err, NotNil)
 	c.Check(packet, IsNil)
 	c.Check(err.Error(), Equals, "LightSetPower.Duration would overflow uint32")
 }
 
-func (*TestSuite) TestLightSetPower_UnmarshalPacket(c *C) {
+func (t *TestSuite) TestLightSetPower_UnmarshalPacket(c *C) {
 	var err error
-	order := binary.LittleEndian
 	buf := &bytes.Buffer{}
 
-	c.Assert(binary.Write(buf, order, uint16(4)), IsNil)  // Level
-	c.Assert(binary.Write(buf, order, uint32(22)), IsNil) // Duration
+	c.Assert(binary.Write(buf, t.order, uint16(4)), IsNil)  // Level
+	c.Assert(binary.Write(buf, t.order, uint32(22)), IsNil) // Duration
 
 	lsp := &LightSetPower{}
-	err = lsp.UnmarshalPacket(bytes.NewReader(buf.Bytes()), order)
+	err = lsp.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 	c.Check(lsp.Level, Equals, uint16(4))
 	c.Check(lsp.Duration, Equals, 22*time.Millisecond)
 }
 
-func (*TestSuite) TestLightStatePower_MarshalPacket(c *C) {
+func (t *TestSuite) TestLightStatePower_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
 	var u16 uint16
 
-	order := binary.LittleEndian
-
 	lsp := &LightStatePower{Level: 10}
 
-	packet, err = lsp.MarshalPacket(order)
+	packet, err = lsp.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 
 	reader := bytes.NewReader(packet)
 
 	// Level
-	c.Assert(binary.Read(reader, order, &u16), IsNil)
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
 	c.Check(u16, Equals, uint16(10))
 }
 
-func (*TestSuite) TestLightStatePower_UnmarshalPacket(c *C) {
+func (t *TestSuite) TestLightStatePower_UnmarshalPacket(c *C) {
 	var err error
-	order := binary.LittleEndian
 	buf := &bytes.Buffer{}
 
-	c.Assert(binary.Write(buf, order, uint16(4)), IsNil) // Level
+	c.Assert(binary.Write(buf, t.order, uint16(4)), IsNil) // Level
 
 	lsp := &LightStatePower{}
-	err = lsp.UnmarshalPacket(bytes.NewReader(buf.Bytes()), order)
+	err = lsp.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 	c.Check(lsp.Level, Equals, uint16(4))
 }

--- a/protocol/payloads/payloads_test.go
+++ b/protocol/payloads/payloads_test.go
@@ -5,13 +5,20 @@
 package lifxpayloads
 
 import (
+	"encoding/binary"
 	"testing"
 
 	. "gopkg.in/check.v1"
 )
 
-type TestSuite struct{}
+type TestSuite struct {
+	order binary.ByteOrder
+}
 
 var _ = Suite(&TestSuite{})
 
 func Test(t *testing.T) { TestingT(t) }
+
+func (t *TestSuite) SetUpSuite(c *C) {
+	t.order = binary.LittleEndian
+}

--- a/protocol/protocol_header_test.go
+++ b/protocol/protocol_header_test.go
@@ -11,7 +11,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (*TestSuite) TestProtocolHeaderDeviceTypes(c *C) {
+func (t *TestSuite) TestProtocolHeaderDeviceTypes(c *C) {
 	c.Check(DeviceGetService, Equals, uint16(2))
 	c.Check(DeviceStateService, Equals, uint16(3))
 	c.Check(DeviceGetHostInfo, Equals, uint16(12))
@@ -41,7 +41,7 @@ func (*TestSuite) TestProtocolHeaderDeviceTypes(c *C) {
 	c.Check(DeviceEchoResponse, Equals, uint16(59))
 }
 
-func (*TestSuite) TestProtocolHeaderLightTypes(c *C) {
+func (t *TestSuite) TestProtocolHeaderLightTypes(c *C) {
 	c.Check(LightGet, Equals, uint16(101))
 	c.Check(LightSetColor, Equals, uint16(102))
 	c.Check(LightState, Equals, uint16(107))
@@ -50,7 +50,7 @@ func (*TestSuite) TestProtocolHeaderLightTypes(c *C) {
 	c.Check(LightStatePower, Equals, uint16(118))
 }
 
-func (*TestSuite) TestProtocolHeader_MarshalPacket(c *C) {
+func (t *TestSuite) TestProtocolHeader_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
 	var u64 uint64
@@ -65,7 +65,7 @@ func (*TestSuite) TestProtocolHeader_MarshalPacket(c *C) {
 		ReservedEnd: 3,
 	}
 
-	packet, err = ph.MarshalPacket(binary.LittleEndian)
+	packet, err = ph.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 	c.Assert(len(packet), Equals, ProtocolHeaderByteSize)
@@ -73,17 +73,17 @@ func (*TestSuite) TestProtocolHeader_MarshalPacket(c *C) {
 	reader := bytes.NewReader(packet)
 
 	// read the first reserved block
-	err = binary.Read(reader, binary.LittleEndian, &u64)
+	err = binary.Read(reader, t.order, &u64)
 	c.Assert(err, IsNil)
 	c.Check(u64, Equals, uint64(1))
 
 	// read the type field
-	err = binary.Read(reader, binary.LittleEndian, &u16)
+	err = binary.Read(reader, t.order, &u16)
 	c.Assert(err, IsNil)
 	c.Check(u16, Equals, uint16(2))
 
 	// read the second reserved block
-	err = binary.Read(reader, binary.LittleEndian, &u16)
+	err = binary.Read(reader, t.order, &u16)
 	c.Assert(err, IsNil)
 	c.Check(u16, Equals, uint16(3))
 
@@ -96,7 +96,7 @@ func (*TestSuite) TestProtocolHeader_MarshalPacket(c *C) {
 		ReservedEnd: 3000,
 	}
 
-	packet, err = ph.MarshalPacket(binary.LittleEndian)
+	packet, err = ph.MarshalPacket(t.order)
 	c.Assert(err, IsNil)
 	c.Assert(packet, NotNil)
 	c.Assert(len(packet), Equals, ProtocolHeaderByteSize)
@@ -104,51 +104,51 @@ func (*TestSuite) TestProtocolHeader_MarshalPacket(c *C) {
 	reader = bytes.NewReader(packet)
 
 	// read the first reserved block
-	err = binary.Read(reader, binary.LittleEndian, &u64)
+	err = binary.Read(reader, t.order, &u64)
 	c.Assert(err, IsNil)
 	c.Check(u64, Equals, uint64(100))
 
 	// read the type field
-	err = binary.Read(reader, binary.LittleEndian, &u16)
+	err = binary.Read(reader, t.order, &u16)
 	c.Assert(err, IsNil)
 	c.Check(u16, Equals, uint16(42))
 
 	// read the second reserved block
-	err = binary.Read(reader, binary.LittleEndian, &u16)
+	err = binary.Read(reader, t.order, &u16)
 	c.Assert(err, IsNil)
 	c.Check(u16, Equals, uint16(3000))
 }
 
-func (*TestSuite) TestProtocolHeader_UnmarshalPacket(c *C) {
+func (t *TestSuite) TestProtocolHeader_UnmarshalPacket(c *C) {
 	var err error
 
 	buf := &bytes.Buffer{}
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(3)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint16(1)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(2)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint64(3)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint16(1)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint64(2)), IsNil)
 
 	//
 	// Test that Unmarshaling works
 	//
 	ph := &ProtocolHeader{}
 
-	err = ph.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	err = ph.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 	c.Check(ph.Reserved, Equals, uint64(3))
 	c.Check(ph.Type, Equals, uint16(1))
 	c.Check(ph.ReservedEnd, Equals, uint16(2))
 
 	buf.Reset()
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(42)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint16(84)), IsNil)
-	c.Assert(binary.Write(buf, binary.LittleEndian, uint64(9001)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint64(42)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint16(84)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint64(9001)), IsNil)
 
 	//
 	// Test that Unmarshaling works with different inputs
 	//
 	ph = &ProtocolHeader{}
 
-	err = ph.UnmarshalPacket(bytes.NewReader(buf.Bytes()), binary.LittleEndian)
+	err = ph.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order)
 	c.Assert(err, IsNil)
 	c.Check(ph.Reserved, Equals, uint64(42))
 	c.Check(ph.Type, Equals, uint16(84))

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -5,13 +5,20 @@
 package lifxprotocol
 
 import (
+	"encoding/binary"
 	"testing"
 
 	. "gopkg.in/check.v1"
 )
 
-type TestSuite struct{}
+type TestSuite struct {
+	order binary.ByteOrder
+}
 
 var _ = Suite(&TestSuite{})
 
 func Test(t *testing.T) { TestingT(t) }
+
+func (t *TestSuite) SetUpSuite(c *C) {
+	t.order = binary.LittleEndian
+}


### PR DESCRIPTION
Instead of using `binary.LittleEndian` everywhere in the tests, I've added an `order` field on the `TestSuite` struct and just use that.
