### PR TITLE
add remaining Device message payloads

### DIFF
--- a/protocol/payloads/device.go
+++ b/protocol/payloads/device.go
@@ -7,8 +7,67 @@ package lifxpayloads
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"io"
 )
+
+// DeviceLabel is the type corresponding to how the name of a device (the label)
+// is sent over the wire. This is a 32 byte array, so helper methods exist to
+// convert a slice to this type. This is NOT a payload to be send with a message.
+type DeviceLabel [32]byte
+
+// NewDeviceLabel is a function that takes a byte slice and returns a DeviceLabel.
+// If the length of the byte slice is greater than 32 this will return an error.
+func NewDeviceLabel(data []byte) (DeviceLabel, error) {
+	if len(data) > 32 {
+		return [32]byte{}, errors.New("the slice cannot be larger than 32 bytes")
+	}
+
+	dl := NewDeviceLabelTrunc(data)
+
+	return dl, nil
+}
+
+// NewDeviceLabelTrunc is a function that takes a byte slice and returns a
+// DeviceLabel. If the length of the byte slice is greater than 32 this will
+// truncate the remaining bytes.
+func NewDeviceLabelTrunc(data []byte) DeviceLabel {
+	var dl DeviceLabel
+
+	loops := len(data)
+
+	if loops > 32 {
+		loops = 32
+	}
+
+	for i := 0; i < loops; i++ {
+		dl[i] = data[i]
+	}
+
+	return dl
+}
+
+// DeviceEchoPayload is a struct representing the payload for both the
+// EchoRequest and EchoResponse message types.
+type DeviceEchoPayload [64]byte
+
+// NewDeviceEchoPayloadTrunc takes a byte slice and returns the corresponding
+// DeviceEchoPayload.
+func NewDeviceEchoPayloadTrunc(data []byte) DeviceEchoPayload {
+	var dep DeviceEchoPayload
+
+	loops := len(data)
+
+	if loops > len(dep) {
+		loops = len(dep)
+	}
+
+	for i := 0; i < loops; i++ {
+		dep[i] = data[i]
+	}
+
+	return dep
+}
 
 // DeviceStateService is the response to the DeviceGetService message.
 //
@@ -274,5 +333,304 @@ func (dswf *DeviceStateWifiFirmware) UnmarshalPacket(data io.Reader, order binar
 		return
 	}
 
+	return
+}
+
+// DeviceStatePower is the struct representing the payload for the power level
+// of a device. The device sends this payload if the GetPower message is sent.
+// The device expects this payload for the SetPower message.
+type DeviceStatePower struct {
+	Level uint16
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dsp *DeviceStatePower) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	if err := binary.Write(buf, order, dsp.Level); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dsp *DeviceStatePower) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	return binary.Read(data, order, &dsp.Level)
+}
+
+// DeviceStateLabel is a struct representing the payload for setting and
+// receiving the device label. The device sends this payload when responding
+// to GetLabel with a StateLabel message. The client sends this payloads when
+// sending a SetLabel message.
+type DeviceStateLabel struct {
+	Label DeviceLabel
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dsl *DeviceStateLabel) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	for i := 0; i < len(dsl.Label); i++ {
+		if err := binary.Write(buf, order, dsl.Label[i]); err != nil {
+			return nil, err
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dsl *DeviceStateLabel) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	for i := 0; i < len(dsl.Label); i++ {
+		if err = binary.Read(data, order, &dsl.Label[i]); err != nil {
+			return
+		}
+	}
+	return
+}
+
+// DeviceStateVersion is a struct respresenting the payload a device sends
+// with the StateVersion message. It provides the hardware verson for the device.
+type DeviceStateVersion struct {
+	// Vendor is the Vendor ID
+	Vendor uint32
+
+	// Product is the Product ID
+	Product uint32
+
+	// Version is the hardware version
+	Version uint32
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dsv *DeviceStateVersion) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	if err := binary.Write(buf, order, dsv.Vendor); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, dsv.Product); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, dsv.Version); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dsv *DeviceStateVersion) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	if err = binary.Read(data, order, &dsv.Vendor); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &dsv.Product); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &dsv.Version); err != nil {
+		return
+	}
+
+	return
+}
+
+// DeviceStateInfo is the struct representation of the payload for the StateInfo
+// message. This message type provides time-based information of the device.
+type DeviceStateInfo struct {
+	// Time is the current time in nanoseconds since the UNIX epoch
+	Time uint64
+
+	// Uptime is the time since last power on in nanoseconds
+	Uptime uint64
+
+	// Downtime is the last power off length in nanoseconds (accuracy of ~5s)
+	Downtime uint64
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dsi *DeviceStateInfo) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	if err := binary.Write(buf, order, dsi.Time); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, dsi.Uptime); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(buf, order, dsi.Downtime); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dsi *DeviceStateInfo) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	if err = binary.Read(data, order, &dsi.Time); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &dsi.Uptime); err != nil {
+		return
+	}
+
+	if err = binary.Read(data, order, &dsi.Downtime); err != nil {
+		return
+	}
+
+	return
+}
+
+// DeviceStateLocation location is the struct representing the device's location as
+// sent by the StateLocation message.
+type DeviceStateLocation struct {
+	Location  [16]byte
+	Label     DeviceLabel
+	UpdatedAt uint64
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dsl *DeviceStateLocation) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	for i := 0; i < len(dsl.Location); i++ {
+		if err := binary.Write(buf, order, dsl.Location[i]); err != nil {
+			return nil, err
+		}
+	}
+
+	for i := 0; i < len(dsl.Label); i++ {
+		if err := binary.Write(buf, order, dsl.Label[i]); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := binary.Write(buf, order, dsl.UpdatedAt); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dsl *DeviceStateLocation) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	for i := 0; i < len(dsl.Location); i++ {
+		if err = binary.Read(data, order, &dsl.Location[i]); err != nil {
+			return
+		}
+	}
+
+	for i := 0; i < len(dsl.Label); i++ {
+		if err = binary.Read(data, order, &dsl.Label[i]); err != nil {
+			return
+		}
+	}
+
+	if err = binary.Read(data, order, &dsl.UpdatedAt); err != nil {
+		return
+	}
+
+	return
+}
+
+// DeviceStateGroup location is the struct representing the device's group as
+// sent by the StateGroup message.
+type DeviceStateGroup struct {
+	Group     [16]byte
+	Label     DeviceLabel
+	UpdatedAt uint64
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dsg *DeviceStateGroup) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	for i := 0; i < len(dsg.Group); i++ {
+		if err := binary.Write(buf, order, dsg.Group[i]); err != nil {
+			return nil, err
+		}
+	}
+
+	for i := 0; i < len(dsg.Label); i++ {
+		if err := binary.Write(buf, order, dsg.Label[i]); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := binary.Write(buf, order, dsg.UpdatedAt); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (dsg *DeviceStateGroup) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	for i := 0; i < len(dsg.Group); i++ {
+		if err = binary.Read(data, order, &dsg.Group[i]); err != nil {
+			return
+		}
+	}
+
+	for i := 0; i < len(dsg.Label); i++ {
+		if err = binary.Read(data, order, &dsg.Label[i]); err != nil {
+			return
+		}
+	}
+
+	if err = binary.Read(data, order, &dsg.UpdatedAt); err != nil {
+		return
+	}
+
+	return
+}
+
+// DeviceEcho is a struct that represents the payload for both an EchoRequest
+// and an EchoResponse message.
+type DeviceEcho struct {
+	Payload DeviceEchoPayload
+}
+
+// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (de *DeviceEcho) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	for i := 0; i < len(de.Payload); i++ {
+		if err := binary.Write(buf, order, de.Payload[i]); err != nil {
+			return nil, err
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// interface.
+func (de *DeviceEcho) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	for i := 0; i < len(de.Payload); i++ {
+		if err = binary.Read(data, order, &de.Payload[i]); err != nil {
+			return
+		}
+	}
 	return
 }

--- a/protocol/payloads/lights.go
+++ b/protocol/payloads/lights.go
@@ -176,7 +176,7 @@ type LightState struct {
 	Power uint16
 
 	// Label is the user-identifiable name for the device.
-	Label [32]byte
+	Label DeviceLabel
 
 	ReservedB uint64
 }


### PR DESCRIPTION
This adds the remaining Device payload structs and tests to ensure marshaling and unmarshaling works.
