### PR TITLE
add support for marshaling/unmarshaling a full LIFX packet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: go
 go:
   - 1.5.3
-  - 1.6rc2
-matrix:
-  allow_failures:
-    - go: 1.6rc2
+  - 1.6
 script: go test -v ./... -check.vv
 sudo: false
 notifications:

--- a/protocol/frame_test.go
+++ b/protocol/frame_test.go
@@ -68,7 +68,7 @@ func (t *TestSuite) TestFrame_MarshalPacket(c *C) {
 	//
 	frame = &Frame{
 		Size:        10,
-		Origin:      0,
+		Origin:      3,
 		Tagged:      false,
 		Addressable: true,
 		Protocol:    4095,
@@ -90,7 +90,7 @@ func (t *TestSuite) TestFrame_MarshalPacket(c *C) {
 	// Read the middle fields that are joined together
 	err = binary.Read(reader, t.order, &u16)
 	c.Assert(err, IsNil)
-	c.Check(uint8(u16>>14), Equals, uint8(0)) // Origin
+	c.Check(uint8(u16>>14), Equals, uint8(3)) // Origin
 	c.Check(u16>>13&1, Equals, uint16(0))     // Tagged
 	c.Check(u16>>12&1, Equals, uint16(1))     // Addressable
 	c.Check(u16<<4>>4, Equals, uint16(4095))  // Protocol

--- a/protocol/header.go
+++ b/protocol/header.go
@@ -10,6 +10,9 @@ import (
 	"io"
 )
 
+// HeaderByteSize is the size in bytes of the header of the message.
+const HeaderByteSize int = FrameByteSize + FrameAddressByteSize + ProtocolHeaderByteSize
+
 // Header is a struct that combines the individual portions of the header
 type Header struct {
 	// Frame is the header component that gives some information about
@@ -26,7 +29,7 @@ type Header struct {
 	ProtocolHeader *ProtocolHeader
 }
 
-// MarshalPackage is a funtion that implements the ProtocolComponent interface.
+// MarshalPacket is a function that implements the Marshaler interface.
 func (h *Header) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	if h.Frame == nil || h.FrameAddress == nil || h.ProtocolHeader == nil {
 		return nil, errors.New("none of the fields in the struct can be nil")
@@ -52,37 +55,26 @@ func (h *Header) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 
 	// allocate the full slice now and manually set the bytes in loops
 	// later -- this is the most optimal way to do this
-	packet := make([]byte, len(frame)+len(frameAddress)+len(protocolHeader))
+	packet := make([]byte, HeaderByteSize)
 
-	// pointer for the packet byte slice
-	// we use it to know which byte we are setting
-	var j int
+	fraStart := FrameByteSize
+	fraEnd := fraStart + FrameAddressByteSize
+	phStart := fraEnd
+	phEnd := phStart + ProtocolHeaderByteSize
 
-	// loop over the frame bytes and put them in the packet slice
-	// loop over the frameAddress bytes and put them in the packet slice
-	// using the j pointer to put the bytes in the right location within
-	// packet
-	for i := 0; i < len(frame); i++ {
-		packet[j] = frame[i]
-		j++ // move pointer
-	}
+	// copy the Frame to packet buffer
+	copy(packet, frame)
 
-	// loop over the frameAddress bytes and put them in the packet slice
-	for i := 0; i < len(frameAddress); i++ {
-		packet[j] = frameAddress[i]
-		j++
-	}
+	// copy the FrameAddress to the packet buffer
+	copy(packet[fraStart:fraEnd], frameAddress)
 
-	// loop over the protocolHeader bytes and put them in the packet slice
-	for i := 0; i < len(protocolHeader); i++ {
-		packet[j] = protocolHeader[i]
-		j++
-	}
+	// copy the ProtocolHeader to the packet buffer
+	copy(packet[phStart:phEnd], protocolHeader)
 
 	return packet, nil
 }
 
-// UnmarshalPackage is a funtion that implements the ProtocolComponent interface.
+// UnmarshalPacket is a function that satisfies the Unmarshaler interface.
 func (h *Header) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	if err = h.Frame.UnmarshalPacket(data, order); err != nil {
 		return

--- a/protocol/payloads/device.go
+++ b/protocol/payloads/device.go
@@ -47,7 +47,7 @@ func NewDeviceLabelTrunc(data []byte) DeviceLabel {
 	return dl
 }
 
-// DeviceEchoPayload is a struct representing the payload for both the
+// DeviceEchoPayload is a type representing the payload for both the
 // EchoRequest and EchoResponse message types.
 type DeviceEchoPayload [64]byte
 
@@ -84,7 +84,7 @@ type DeviceStateService struct {
 	Port uint32
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (dss *DeviceStateService) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
@@ -100,7 +100,7 @@ func (dss *DeviceStateService) MarshalPacket(order binary.ByteOrder) ([]byte, er
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (dss *DeviceStateService) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	if err = binary.Read(data, order, &dss.Service); err != nil {
@@ -129,7 +129,7 @@ type DeviceStateHostInfo struct {
 	Reserved int16
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (dshi *DeviceStateHostInfo) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
@@ -153,7 +153,7 @@ func (dshi *DeviceStateHostInfo) MarshalPacket(order binary.ByteOrder) ([]byte, 
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (dshi *DeviceStateHostInfo) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	if err = binary.Read(data, order, &dshi.Signal); err != nil {
@@ -187,7 +187,7 @@ type DeviceStateHostFirmware struct {
 	Version uint32
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (dshf *DeviceStateHostFirmware) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
@@ -207,7 +207,7 @@ func (dshf *DeviceStateHostFirmware) MarshalPacket(order binary.ByteOrder) ([]by
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (dshf *DeviceStateHostFirmware) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	if err = binary.Read(data, order, &dshf.Build); err != nil {
@@ -240,7 +240,7 @@ type DeviceStateWifiInfo struct {
 	Reserved int16
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (dswi *DeviceStateWifiInfo) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
@@ -264,7 +264,7 @@ func (dswi *DeviceStateWifiInfo) MarshalPacket(order binary.ByteOrder) ([]byte, 
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (dswi *DeviceStateWifiInfo) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	if err = binary.Read(data, order, &dswi.Signal); err != nil {
@@ -298,7 +298,7 @@ type DeviceStateWifiFirmware struct {
 	Version uint32
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (dswf *DeviceStateWifiFirmware) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
@@ -318,7 +318,7 @@ func (dswf *DeviceStateWifiFirmware) MarshalPacket(order binary.ByteOrder) ([]by
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (dswf *DeviceStateWifiFirmware) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	if err = binary.Read(data, order, &dswf.Build); err != nil {
@@ -343,7 +343,7 @@ type DeviceStatePower struct {
 	Level uint16
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (dsp *DeviceStatePower) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
@@ -355,7 +355,7 @@ func (dsp *DeviceStatePower) MarshalPacket(order binary.ByteOrder) ([]byte, erro
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (dsp *DeviceStatePower) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	return binary.Read(data, order, &dsp.Level)
@@ -369,7 +369,7 @@ type DeviceStateLabel struct {
 	Label DeviceLabel
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (dsl *DeviceStateLabel) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
@@ -383,7 +383,7 @@ func (dsl *DeviceStateLabel) MarshalPacket(order binary.ByteOrder) ([]byte, erro
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (dsl *DeviceStateLabel) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	for i := 0; i < len(dsl.Label); i++ {
@@ -407,7 +407,7 @@ type DeviceStateVersion struct {
 	Version uint32
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (dsv *DeviceStateVersion) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
@@ -427,7 +427,7 @@ func (dsv *DeviceStateVersion) MarshalPacket(order binary.ByteOrder) ([]byte, er
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (dsv *DeviceStateVersion) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	if err = binary.Read(data, order, &dsv.Vendor); err != nil {
@@ -458,7 +458,7 @@ type DeviceStateInfo struct {
 	Downtime uint64
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (dsi *DeviceStateInfo) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
@@ -478,7 +478,7 @@ func (dsi *DeviceStateInfo) MarshalPacket(order binary.ByteOrder) ([]byte, error
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (dsi *DeviceStateInfo) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	if err = binary.Read(data, order, &dsi.Time); err != nil {
@@ -504,7 +504,7 @@ type DeviceStateLocation struct {
 	UpdatedAt uint64
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (dsl *DeviceStateLocation) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
@@ -528,7 +528,7 @@ func (dsl *DeviceStateLocation) MarshalPacket(order binary.ByteOrder) ([]byte, e
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (dsl *DeviceStateLocation) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	for i := 0; i < len(dsl.Location); i++ {
@@ -558,7 +558,7 @@ type DeviceStateGroup struct {
 	UpdatedAt uint64
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (dsg *DeviceStateGroup) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
@@ -582,7 +582,7 @@ func (dsg *DeviceStateGroup) MarshalPacket(order binary.ByteOrder) ([]byte, erro
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (dsg *DeviceStateGroup) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	for i := 0; i < len(dsg.Group); i++ {
@@ -610,7 +610,7 @@ type DeviceEcho struct {
 	Payload DeviceEchoPayload
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (de *DeviceEcho) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
@@ -624,7 +624,7 @@ func (de *DeviceEcho) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (de *DeviceEcho) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	for i := 0; i < len(de.Payload); i++ {

--- a/protocol/payloads/lights.go
+++ b/protocol/payloads/lights.go
@@ -41,7 +41,7 @@ type LightHSBK struct {
 	Kelvin uint16
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (hsbk *LightHSBK) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
@@ -65,7 +65,7 @@ func (hsbk *LightHSBK) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (hsbk *LightHSBK) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	if err = binary.Read(data, order, &hsbk.Hue); err != nil {
@@ -105,7 +105,7 @@ func msToDur(ms uint32) time.Duration {
 	return time.Duration(ms) * time.Millisecond
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (lsc *LightSetColor) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	if lsc.Color == nil {
@@ -140,7 +140,7 @@ func (lsc *LightSetColor) MarshalPacket(order binary.ByteOrder) ([]byte, error) 
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (lsc *LightSetColor) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	if err = binary.Read(data, order, &lsc.Reserved); err != nil {
@@ -167,7 +167,7 @@ func (lsc *LightSetColor) UnmarshalPacket(data io.Reader, order binary.ByteOrder
 }
 
 // LightState is the struct representing the payload sent by the device
-// to preovide the current light state.
+// to provide the current light state.
 type LightState struct {
 	Color    *LightHSBK
 	Reserved uint16
@@ -181,7 +181,7 @@ type LightState struct {
 	ReservedB uint64
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (ls *LightState) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	if ls.Color == nil {
@@ -221,7 +221,7 @@ func (ls *LightState) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (ls *LightState) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	if ls.Color == nil {
@@ -263,7 +263,7 @@ type LightSetPower struct {
 	Duration time.Duration
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (lsp *LightSetPower) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	// if the length of the Duration would overflow uint32
@@ -284,7 +284,7 @@ func (lsp *LightSetPower) MarshalPacket(order binary.ByteOrder) ([]byte, error) 
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (lsp *LightSetPower) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
 	if err = binary.Read(data, order, &lsp.Level); err != nil {
@@ -308,7 +308,7 @@ type LightStatePower struct {
 	Level uint16
 }
 
-// MarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (lsp *LightStatePower) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
@@ -320,7 +320,7 @@ func (lsp *LightStatePower) MarshalPacket(order binary.ByteOrder) ([]byte, error
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that implements the lifxprotocol.ProtocolComponent
+// UnmarshalPacket is a function that satisfies the lifxprotocol.Unmarshaler
 // interface.
 func (lsp *LightStatePower) UnmarshalPacket(data io.Reader, order binary.ByteOrder) error {
 	return binary.Read(data, order, &lsp.Level)

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -15,13 +15,34 @@ package lifxprotocol
 
 import (
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
+
+	"github.com/theckman/go-lifx/protocol/payloads"
 )
 
-// ProtocolComponent is the interface used for each component to implement.
-type ProtocolComponent interface {
+const maxUint16 = int(^uint16(0))
+
+// Marshaler is the interface for Marshaling packets.
+// The order parameter can either be binary.LittleEndian or binary.BigEndian.
+// The LIFX protocol uses little-endian encoding at the time of writing.
+type Marshaler interface {
 	MarshalPacket(order binary.ByteOrder) ([]byte, error)
+}
+
+// Unmarshaler is the interface for Unmarshaling packets.
+// The data parameter is an io.Reader that contains the contents of the packet.
+// The order parameter can either be binary.LittleEndian or binary.BigEndian.
+// The LIFX protocol uses little-endian encoding at the time of writing.
+type Unmarshaler interface {
 	UnmarshalPacket(data io.Reader, order binary.ByteOrder) error
+}
+
+// PacketComponent is the interface used for each component to implement.
+type PacketComponent interface {
+	Marshaler
+	Unmarshaler
 }
 
 // Packet is the struct for an individual message whether inbound or
@@ -35,5 +56,148 @@ type Packet struct {
 	// Payload is the message payload. The contents of the payload vary
 	// based on what is being sent. The recipient knows how to parse this
 	// message based on the value of the Header.ProtocolHeader.Type field.
-	Payload ProtocolComponent
+	Payload PacketComponent
+}
+
+// MarshalPacket is a function that satisfies the Marshaler interface.
+func (p *Packet) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
+	if p.Header == nil {
+		return nil, errors.New("the Header field cannot be nil")
+	}
+
+	if p.Payload == nil {
+		return nil, errors.New("the Payload field cannot be nil")
+	}
+
+	payload, err := p.Payload.MarshalPacket(order)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// calculate the total byte size
+	tbs := HeaderByteSize + len(payload)
+
+	// check for overflow of Header.Frame.Size field
+	if tbs > maxUint16 {
+		return nil, fmt.Errorf("size of packet (%d) would overflow Packet.Header.Frame.Size uint16 field (max %d)", tbs, maxUint16)
+	}
+
+	// we now know how big the message is now, so let's set it
+	p.Header.Frame.Size = uint16(tbs)
+
+	header, err := p.Header.MarshalPacket(order)
+
+	if err != nil {
+		return nil, err
+	}
+
+	packet := make([]byte, tbs)
+
+	// copy the header to the beginning of the packet
+	copy(packet, header)
+
+	// copy the payload immediately following the header
+	copy(packet[HeaderByteSize:tbs], payload)
+
+	return packet, nil
+}
+
+func packetComponentByType(t uint16) PacketComponent {
+	switch t {
+	case DeviceStateService:
+		return &lifxpayloads.DeviceStateService{}
+
+	case DeviceStateHostInfo:
+		return &lifxpayloads.DeviceStateHostInfo{}
+
+	case DeviceStateHostFirmware:
+		return &lifxpayloads.DeviceStateHostFirmware{}
+
+	case DeviceStateWifiInfo:
+		return &lifxpayloads.DeviceStateWifiInfo{}
+
+	case DeviceStateWifiFirmware:
+		return &lifxpayloads.DeviceStateWifiFirmware{}
+
+	case DeviceStatePower, DeviceSetPower:
+		return &lifxpayloads.DeviceStatePower{}
+
+	case DeviceStateLabel, DeviceSetLabel:
+		return &lifxpayloads.DeviceStateLabel{}
+
+	case DeviceStateVersion:
+		return &lifxpayloads.DeviceStateVersion{}
+
+	case DeviceStateInfo:
+		return &lifxpayloads.DeviceStateInfo{}
+
+	case DeviceStateLocation:
+		return &lifxpayloads.DeviceStateInfo{}
+
+	case DeviceStateGroup:
+		return &lifxpayloads.DeviceStateGroup{}
+
+	case DeviceEchoResponse, DeviceEchoRequest:
+		return &lifxpayloads.DeviceEcho{}
+
+	case LightSetColor:
+		return &lifxpayloads.LightSetColor{}
+
+	case LightState:
+		return &lifxpayloads.LightState{}
+
+	case LightSetPower:
+		return &lifxpayloads.LightSetPower{}
+
+	case LightStatePower:
+		return &lifxpayloads.LightStatePower{}
+
+	default:
+		return nil
+	}
+}
+
+func (p *Packet) unmarshalPayload(data io.Reader, order binary.ByteOrder) (PacketComponent, error) {
+	if p.Header.ProtocolHeader == nil {
+		return nil, errors.New("the ProtocolHeader cannot be nil")
+	}
+
+	var pc PacketComponent
+
+	// figure out the payload type so we can unmarshal it
+	if pc = packetComponentByType(p.Header.ProtocolHeader.Type); pc == nil {
+		return nil, errors.New("unknown message type")
+	}
+
+	if err := pc.UnmarshalPacket(data, order); err != nil {
+		return nil, err
+	}
+
+	return pc, nil
+}
+
+// UnmarshalPacket is a function that implements the Unmarshaler interface.
+func (p *Packet) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	hdr := &Header{
+		Frame:          &Frame{},
+		FrameAddress:   &FrameAddress{},
+		ProtocolHeader: &ProtocolHeader{},
+	}
+
+	if err = hdr.UnmarshalPacket(data, order); err != nil {
+		return
+	}
+
+	p.Header = hdr
+
+	payload, err := p.unmarshalPayload(data, order)
+
+	if err != nil {
+		return
+	}
+
+	p.Payload = payload
+
+	return
 }

--- a/protocol/protocol_header.go
+++ b/protocol/protocol_header.go
@@ -72,6 +72,7 @@ type ProtocolHeader struct {
 	ReservedEnd uint16
 }
 
+// MarshalPacket is a function that implements the Marshaler interface.
 func (ph *ProtocolHeader) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
 
@@ -93,11 +94,15 @@ func (ph *ProtocolHeader) MarshalPacket(order binary.ByteOrder) ([]byte, error) 
 	return buf.Bytes(), nil
 }
 
-// UnmarshalPacket is a function that satisfies the ProtocolComponent interface.
+// UnmarshalPacket is a function that satisfies the Unmarshaler interface.
 // It takes an io.Reader and pulls unmarshals the packet in to the
 // ProtocolHeader struct fields. It uses the order parameter to correctly
 // unpack the values.
 func (ph *ProtocolHeader) UnmarshalPacket(data io.Reader, order binary.ByteOrder) (err error) {
+	if ph == nil {
+		ph = &ProtocolHeader{}
+	}
+
 	if err = binary.Read(data, order, &ph.Reserved); err != nil {
 		return
 	}

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -5,20 +5,256 @@
 package lifxprotocol
 
 import (
+	"bytes"
 	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"net"
 	"testing"
+	"time"
+
+	"github.com/theckman/go-lifx/protocol/payloads"
+	"github.com/theckman/go-lifx/util"
 
 	. "gopkg.in/check.v1"
 )
 
+const MaxUint32 = ^uint32(0)
+
 type TestSuite struct {
-	order binary.ByteOrder
+	order  binary.ByteOrder
+	source uint32
+	seed   int64
 }
 
 var _ = Suite(&TestSuite{})
 
 func Test(t *testing.T) { TestingT(t) }
 
+func (t *TestSuite) generateSeed(c *C) {
+	tmpSeed := rand.NewSource(time.Now().UnixNano())
+	r := rand.New(tmpSeed)
+
+	t.seed = r.Int63()
+	fmt.Printf("\n!!!! github.com/theckman/go-lifx/protocol testing rand seed: %d\n\n", t.seed)
+
+	rand.Seed(t.seed)
+}
+
 func (t *TestSuite) SetUpSuite(c *C) {
+	t.generateSeed(c)
+
 	t.order = binary.LittleEndian
+
+	// generate a pseudorandom value between 0 and the largest uint32
+	t.source = uint32(rand.Int63n(int64(MaxUint32)))
+}
+
+func (t *TestSuite) TestPacket_MarshalPacket(c *C) {
+	var packet []byte
+	var err error
+	var u64 uint64
+	var u32 uint32
+	var u16 uint16
+	var u8 uint8
+
+	hwaddr, err := net.ParseMAC("01:23:45:67:89:ab")
+	c.Assert(err, IsNil)
+
+	rb := [6]uint8{40, 41, 42, 43, 44, 45}
+	pl := [64]byte{0, 1, 2, 3, 4, 5, 6, 7}
+
+	p := &Packet{
+		Header: &Header{
+			Frame: &Frame{
+				Origin:      3,
+				Tagged:      true,
+				Addressable: true,
+				Protocol:    1024,
+				Source:      t.source,
+			},
+			FrameAddress: &FrameAddress{
+				Target:        hwaddr,
+				ReservedBlock: rb,
+				Reserved:      50,
+				AckRequired:   true,
+				ResRequired:   true,
+				Sequence:      128,
+			},
+			ProtocolHeader: &ProtocolHeader{
+				Reserved:    200,
+				Type:        DeviceEchoResponse,
+				ReservedEnd: 2020,
+			},
+		},
+		Payload: &lifxpayloads.DeviceEcho{
+			Payload: pl,
+		},
+	}
+
+	packet, err = p.MarshalPacket(t.order)
+	c.Assert(err, IsNil)
+	c.Assert(len(packet), Equals, HeaderByteSize+64)
+
+	reader := bytes.NewReader(packet)
+
+	//
+	// Test Header.Frame marshaling
+	//
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(HeaderByteSize+64)) // Frame.Size
+
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
+	c.Check(uint8(u16>>14), Equals, uint8(3)) // Frame.Origin
+	c.Check(u16>>13&1, Equals, uint16(1))     // Frame.Tagged
+	c.Check(u16>>12&1, Equals, uint16(1))     // Frame.Addressable
+	c.Check(u16<<4>>4, Equals, uint16(1024))  // Frame.Protocol
+
+	c.Assert(binary.Read(reader, t.order, &u32), IsNil)
+	c.Check(u32, Equals, t.source) // Frame.Source
+
+	//
+	// Test Header.FrameAddress marshaling
+	//
+	c.Assert(binary.Read(reader, t.order, &u64), IsNil)
+	hw := lifxutil.Uint64ToHardwareAddr(u64)
+	c.Check(hw.String(), Equals, hwaddr.String()) // FrameAdress.Target
+
+	for i := range rb { // FrameAddress.ReservedBlock
+		c.Assert(binary.Read(reader, t.order, &u8), IsNil)
+		c.Check(u8, Equals, rb[i])
+	}
+
+	c.Assert(binary.Read(reader, t.order, &u8), IsNil)
+	c.Check(u8>>2, Equals, uint8(50))    // FrameAddress.Reserved
+	c.Check((u8>>1)&1, Equals, uint8(1)) // FrameAddress.AckRequired
+	c.Check(u8&1, Equals, uint8(1))      // FrameAddress.ResRequired
+
+	c.Assert(binary.Read(reader, t.order, &u8), IsNil)
+	c.Check(u8, Equals, uint8(128)) // FrameAddress.Sequence
+
+	//
+	// Test Header.ProtocolHeader marshaling
+	//
+	c.Assert(binary.Read(reader, t.order, &u64), IsNil)
+	c.Check(u64, Equals, uint64(200)) // ProtocolHeader.Reserved
+
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
+	c.Check(u16, Equals, DeviceEchoResponse) // ProtocolHeader.Type
+
+	c.Assert(binary.Read(reader, t.order, &u16), IsNil)
+	c.Check(u16, Equals, uint16(2020)) // ProtocolHeader.ReservedEnd
+
+	//
+	// Test Payload marshaling
+	//
+	for i := range pl {
+		c.Assert(binary.Read(reader, t.order, &u8), IsNil)
+		c.Check(u8, Equals, pl[i])
+	}
+}
+
+func (t *TestSuite) TestPacket_UnmarshalPacket(c *C) {
+	var err error
+
+	buf := &bytes.Buffer{}
+
+	origin := uint16(3)
+	tagged := uint16(1)
+	addressable := uint16(1)
+	protocol := uint16(1024)
+
+	u16 := origin<<14 |
+		tagged<<13 |
+		addressable<<12 |
+		protocol<<4>>4
+
+	reserved := uint8(32)
+	ackRequired := uint8(1)
+	resRequired := uint8(1)
+
+	u8 := reserved<<2 |
+		(ackRequired&1)<<1 | (resRequired & 1)
+
+	rb := [6]uint8{40, 41, 42, 43, 44, 45}
+
+	hwaddr, err := net.ParseMAC("01:23:45:67:89:ab")
+	c.Assert(err, IsNil)
+
+	mac := lifxutil.HardwareAddrToUint64(hwaddr)
+
+	// Packet.Header.Frame.Size
+	c.Assert(binary.Write(buf, t.order, uint16(HeaderByteSize+24)), IsNil)
+
+	// Packet.Header.Frame.
+	//		Origin
+	//		Tagged
+	// 		Addressable
+	// 		Protocol
+	c.Assert(binary.Write(buf, t.order, u16), IsNil)
+
+	// Packet.Header.Frame.Source
+	c.Assert(binary.Write(buf, t.order, uint32(1122)), IsNil)
+
+	// Packet.Header.FrameAddress.Target
+	c.Assert(binary.Write(buf, t.order, mac), IsNil)
+
+	// Packet.Header.FrameAddress.ReservedBlock
+	for _, val := range rb {
+		c.Assert(binary.Write(buf, t.order, val), IsNil)
+	}
+
+	// Packet.Header.FrameAddress.
+	//		Reserved
+	//		AckRequired
+	//		ResRequired
+	c.Assert(binary.Write(buf, t.order, u8), IsNil)
+
+	// Packet.Header.FrameAdddress.Sequence
+	c.Assert(binary.Write(buf, t.order, uint8(42)), IsNil)
+
+	// Packet.Header.ProtocolHeader.Reserved
+	c.Assert(binary.Write(buf, t.order, uint64(10101)), IsNil)
+
+	// Packet.Header.ProtocolHeader.Type
+	c.Assert(binary.Write(buf, t.order, DeviceStateInfo), IsNil)
+
+	// Packet.Header.ProtocolHeader.ReservedEnd
+	c.Assert(binary.Write(buf, t.order, uint16(2424)), IsNil)
+
+	// Packet.Payload (lifxpayloads.DeviceStateInfo)
+	c.Assert(binary.Write(buf, t.order, uint64(11223344)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint64(22334455)), IsNil)
+	c.Assert(binary.Write(buf, t.order, uint64(33445566)), IsNil)
+
+	reader := bytes.NewReader(buf.Bytes())
+
+	p := &Packet{}
+
+	err = p.UnmarshalPacket(reader, t.order)
+	c.Assert(err, IsNil)
+
+	c.Check(p.Header.Frame.Size, Equals, uint16(HeaderByteSize+24))
+	c.Check(p.Header.Frame.Origin, Equals, uint8(origin))
+	c.Check(p.Header.Frame.Tagged, Equals, true)
+	c.Check(p.Header.Frame.Addressable, Equals, true)
+	c.Check(p.Header.Frame.Protocol, Equals, protocol)
+	c.Check(p.Header.FrameAddress.Target.String(), Equals, hwaddr.String())
+	c.Check(p.Header.FrameAddress.ReservedBlock, DeepEquals, rb)
+	c.Check(p.Header.FrameAddress.Reserved, Equals, uint8(32))
+	c.Check(p.Header.FrameAddress.AckRequired, Equals, true)
+	c.Check(p.Header.FrameAddress.ResRequired, Equals, true)
+	c.Check(p.Header.FrameAddress.Sequence, Equals, uint8(42))
+	c.Check(p.Header.ProtocolHeader.Reserved, Equals, uint64(10101))
+	c.Check(p.Header.ProtocolHeader.Type, Equals, DeviceStateInfo)
+	c.Check(p.Header.ProtocolHeader.ReservedEnd, Equals, uint16(2424))
+
+	c.Assert(p.Payload, NotNil)
+
+	payload, ok := p.Payload.(*lifxpayloads.DeviceStateInfo)
+	c.Assert(ok, Equals, true)
+	c.Assert(payload, NotNil)
+	c.Check(payload.Time, Equals, uint64(11223344))
+	c.Check(payload.Uptime, Equals, uint64(22334455))
+	c.Check(payload.Downtime, Equals, uint64(33445566))
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,40 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+// Package lifxutil is a helper package that provides utility functionality
+// required by the different subpackges of the lifx package. This utility
+// functionality includes shared functions, as well as shared constants.
+package lifxutil
+
+import "net"
+
+// HardwareAddrToUint64 converts a net.HardwareAddr and returns a
+// uint64 based on the LIFX specification:
+//
+// The target device address is 8 bytes long, when using the 6 byte MAC address
+// then left-justify the value and zero-fill the last two bytes.
+func HardwareAddrToUint64(target net.HardwareAddr) uint64 {
+	return uint64(target[0])<<55 |
+		uint64(target[1])<<47 |
+		uint64(target[2])<<39 |
+		uint64(target[3])<<31 |
+		uint64(target[4])<<23 |
+		uint64(target[5])<<15
+}
+
+// Uint64ToHardwareAddr converts a uint64 value to a net.HardwareAddr
+// based on the LIFX specification rules. See the comment for
+// HardwareAddrToUint64 for more info .
+func Uint64ToHardwareAddr(u64 uint64) net.HardwareAddr {
+	hwaddr := make(net.HardwareAddr, 6)
+
+	hwaddr[0] = byte(u64 >> 55)
+	hwaddr[1] = byte(u64 >> 47)
+	hwaddr[2] = byte(u64 >> 39)
+	hwaddr[3] = byte(u64 >> 31)
+	hwaddr[4] = byte(u64 >> 23)
+	hwaddr[5] = byte(u64 >> 15)
+
+	return hwaddr
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,54 @@
+// Copyright 2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package lifxutil_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/theckman/go-lifx/util"
+
+	. "gopkg.in/check.v1"
+)
+
+type TestSuite struct{}
+
+var _ = Suite(&TestSuite{})
+
+func Test(t *testing.T) { TestingT(t) }
+
+func (*TestSuite) Test_HardwareAddrToUint64(c *C) {
+	var u64 uint64
+
+	hwaddr, err := net.ParseMAC("01:23:45:67:89:ab")
+	c.Assert(err, IsNil)
+
+	result := uint64(hwaddr[0])<<55 |
+		uint64(hwaddr[1])<<47 |
+		uint64(hwaddr[2])<<39 |
+		uint64(hwaddr[3])<<31 |
+		uint64(hwaddr[4])<<23 |
+		uint64(hwaddr[5])<<15
+
+	u64 = lifxutil.HardwareAddrToUint64(hwaddr)
+	c.Check(u64, Equals, result)
+}
+
+func (*TestSuite) Test_Uint64ToHardwareAddr(c *C) {
+	var hw, hwaddr net.HardwareAddr
+
+	hw, err := net.ParseMAC("01:23:45:67:89:ab")
+	c.Assert(err, IsNil)
+
+	u64 := uint64(hw[0])<<55 |
+		uint64(hw[1])<<47 |
+		uint64(hw[2])<<39 |
+		uint64(hw[3])<<31 |
+		uint64(hw[4])<<23 |
+		uint64(hw[5])<<15
+
+	hwaddr = lifxutil.Uint64ToHardwareAddr(u64)
+	c.Check(hwaddr.String(), Equals, hw.String())
+}


### PR DESCRIPTION
This change adds the ability to marshal and unmarshal full pakets. This pieces together all of the individual structs that are used for reading and writing packets that meet the specifications provided by LIFX.

In addition to the changes above, other parts of the codebase were improved:
- better function documentation
- additional code comments for clarity
- use `copy()` instead of looping over slices to combine them together

In addition to these changes change, test this code against 1.6 stable instead of `rc2` on TravisCI.
