### PR TITLE
add fmt.Stringer to PacketComponent interface and implement methods

### DIFF
--- a/protocol/frame.go
+++ b/protocol/frame.go
@@ -76,6 +76,17 @@ func NewFrame() *Frame {
 	}
 }
 
+func (frame *Frame) String() string {
+	if frame == nil {
+		return "<*lifxprotocol.Frame(nil)>"
+	}
+
+	return fmt.Sprintf(
+		"<*lifxprotocol.Frame(%p) Origin: %d, Tagged: %t, Addressable: %t, Protocol: %d, Source: 0x%x>",
+		frame, frame.Origin, frame.Tagged, frame.Addressable, frame.Protocol, frame.Source,
+	)
+}
+
 // MarshalPacket is a function that satisfies the Marshaler interface.
 func (frame *Frame) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	if frame.Origin > MaxFrameOrigin {

--- a/protocol/frame_address.go
+++ b/protocol/frame_address.go
@@ -71,6 +71,21 @@ type FrameAddress struct {
 
 func NewFrameAddress() *FrameAddress { return &FrameAddress{} }
 
+func (fra *FrameAddress) String() string {
+	if fra == nil {
+		return "<*lifxprotocol.FrameAddress(nil)>"
+	}
+
+	if fra.Target == nil {
+		fra.Target = make(net.HardwareAddr, 6)
+	}
+
+	return fmt.Sprintf(
+		"<*lifxprotocol.FrameAddress(%p): Target: %s, AckRequired: %t, ResRequired: %t, Sequence: %d>",
+		fra, fra.Target, fra.AckRequired, fra.ResRequired, fra.Sequence,
+	)
+}
+
 // MarshalPacket is a function that implements the Marshaler interface.
 func (fra *FrameAddress) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	if fra.Reserved > MaxFrameAddressReserved {

--- a/protocol/frame_address_test.go
+++ b/protocol/frame_address_test.go
@@ -7,6 +7,7 @@ package lifxprotocol
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 
 	. "gopkg.in/check.v1"
 )
@@ -15,6 +16,27 @@ func (t *TestSuite) Test_NewFrameAddress(c *C) {
 	var fa *FrameAddress
 	fa = NewFrameAddress()
 	c.Assert(fa, NotNil)
+}
+
+func (*TestSuite) TestFrameAddress_String(c *C) {
+	var str string
+
+	fraddr := &FrameAddress{
+		Target:        []byte{1, 2, 3, 4, 5, 6},
+		ReservedBlock: [6]uint8{0, 0, 0, 0, 0, 0},
+		Reserved:      10,
+		AckRequired:   false,
+		ResRequired:   true,
+		Sequence:      42,
+	}
+
+	exp := fmt.Sprintf(
+		"<*lifxprotocol.FrameAddress(%p): Target: 01:02:03:04:05:06, AckRequired: false, ResRequired: true, Sequence: 42>",
+		fraddr,
+	)
+
+	str = fraddr.String()
+	c.Check(str, Equals, exp)
 }
 
 func (t *TestSuite) TestFrameAddress_MarshalPacket(c *C) {

--- a/protocol/frame_test.go
+++ b/protocol/frame_test.go
@@ -7,6 +7,7 @@ package lifxprotocol
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 
 	. "gopkg.in/check.v1"
 )
@@ -18,6 +19,27 @@ func (t *TestSuite) Test_NewFrame(c *C) {
 	c.Check(f.Origin, Equals, uint8(0))
 	c.Check(f.Addressable, Equals, true)
 	c.Check(f.Protocol, Equals, uint16(1024))
+}
+
+func (*TestSuite) TestFrame_String(c *C) {
+	var str string
+
+	frame := &Frame{
+		Size:        42,
+		Origin:      3,
+		Tagged:      true,
+		Addressable: true,
+		Protocol:    1024,
+		Source:      4242, // 0x1092
+	}
+
+	exp := fmt.Sprintf(
+		"<*lifxprotocol.Frame(%p) Origin: 3, Tagged: true, Addressable: true, Protocol: 1024, Source: 0x1092>",
+		frame,
+	)
+
+	str = frame.String()
+	c.Check(str, Equals, exp)
 }
 
 func (t *TestSuite) TestFrame_MarshalPacket(c *C) {

--- a/protocol/header.go
+++ b/protocol/header.go
@@ -7,6 +7,7 @@ package lifxprotocol
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 )
 
@@ -27,6 +28,37 @@ type Header struct {
 	// ProtocolHeader is the component that contains information about
 	// the payload. It's recommended to use a *ProtocolHeader struct.
 	ProtocolHeader *ProtocolHeader
+}
+
+func (h *Header) String() string {
+	if h == nil {
+		return "<*lifxprotocol.Header(nil)>"
+	}
+
+	var fraString, fraddrString, phString string
+
+	if h.Frame == nil {
+		fraString = "<nil>"
+	} else {
+		fraString = h.Frame.String()
+	}
+
+	if h.FrameAddress == nil {
+		fraddrString = "<nil>"
+	} else {
+		fraddrString = h.FrameAddress.String()
+	}
+
+	if h.ProtocolHeader == nil {
+		phString = "<nil>"
+	} else {
+		phString = h.ProtocolHeader.String()
+	}
+
+	return fmt.Sprintf(
+		"<*lifxprotocol.Header(%p): Frame: %s, FrameAddress: %s, ProtocolHeader: %s>",
+		h, fraString, fraddrString, phString,
+	)
 }
 
 // MarshalPacket is a function that implements the Marshaler interface.

--- a/protocol/header_test.go
+++ b/protocol/header_test.go
@@ -7,9 +7,46 @@ package lifxprotocol
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 
 	. "gopkg.in/check.v1"
 )
+
+func (*TestSuite) TestHeader_String(c *C) {
+	var str string
+
+	frame := &Frame{
+		Size:        8,
+		Origin:      2,
+		Tagged:      true,
+		Addressable: false,
+		Protocol:    1024,
+		Source:      42,
+	}
+
+	fraddr := &FrameAddress{
+		Target:      []byte{1, 2, 3, 4, 5, 6},
+		AckRequired: false,
+		ResRequired: true,
+		Sequence:    42,
+	}
+
+	ph := &ProtocolHeader{Type: 2}
+
+	header := &Header{
+		Frame:          frame,
+		FrameAddress:   fraddr,
+		ProtocolHeader: ph,
+	}
+
+	exp := fmt.Sprintf(
+		"<*lifxprotocol.Header(%p): Frame: %s, FrameAddress: %s, ProtocolHeader: %s>",
+		header, frame, fraddr, ph,
+	)
+
+	str = header.String()
+	c.Check(str, Equals, exp)
+}
 
 func (t *TestSuite) TestHeader_MarshalPacket(c *C) {
 	var packet []byte

--- a/protocol/payloads/device_test.go
+++ b/protocol/payloads/device_test.go
@@ -7,6 +7,8 @@ package lifxpayloads
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"time"
 
 	. "gopkg.in/check.v1"
 )
@@ -114,6 +116,20 @@ func (*TestSuite) TestNewDeviceEchoPayloadTrunc(c *C) {
 	c.Check(label, Equals, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
 }
 
+func (t *TestSuite) TestDeviceStateService_String(c *C) {
+	var str string
+
+	dss := &DeviceStateService{
+		Service: 3,
+		Port:    56700,
+	}
+
+	exp := fmt.Sprintf("<*lifxpayloads.DeviceStateService(%p): Service: 3, Port: 56700>", dss)
+
+	str = dss.String()
+	c.Check(str, Equals, exp)
+}
+
 func (t *TestSuite) TestDeviceStateService_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
@@ -152,6 +168,21 @@ func (t *TestSuite) TestDeviceStateService_UnmarshalPacket(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(dss.Service, Equals, uint8(42))
 	c.Check(dss.Port, Equals, uint32(8484))
+}
+
+func (*TestSuite) TestDeviceStateHostInfo_String(c *C) {
+	var str string
+
+	dshi := &DeviceStateHostInfo{
+		Signal: 0.1234,
+		Tx:     1,
+		Rx:     2,
+	}
+
+	exp := fmt.Sprintf("<*lifxpayloads.DeviceStateHostInfo(%p): Signal: 0.1234000027179718, Tx: 1, Rx: 2>", dshi)
+
+	str = dshi.String()
+	c.Check(str, Equals, exp)
 }
 
 func (t *TestSuite) TestDeviceStateHostInfo_MarshalPacket(c *C) {
@@ -208,6 +239,22 @@ func (t *TestSuite) TestDeviceStateHostInfo_UnmarshalPacket(c *C) {
 	c.Check(dshi.Reserved, Equals, int16(66))
 }
 
+func (*TestSuite) TestDeviceStateHostFirmware_String(c *C) {
+	var str string
+
+	now := time.Now().UTC()
+
+	dshf := &DeviceStateHostFirmware{
+		Build:   uint64(now.UnixNano()),
+		Version: 42,
+	}
+
+	exp := fmt.Sprintf("<*lifxpayloads.DeviceStateHostFirmware(%p): Build: %s, Version: 42>", dshf, now.String())
+
+	str = dshf.String()
+	c.Check(str, Equals, exp)
+}
+
 func (t *TestSuite) TestDeviceStateHostFirmware_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
@@ -253,6 +300,21 @@ func (t *TestSuite) TestDeviceStateHostFirmware_UnmarshalPacket(c *C) {
 	c.Check(dshf.Build, Equals, uint64(42))
 	c.Check(dshf.Reserved, Equals, uint64(84))
 	c.Check(dshf.Version, Equals, uint32(99))
+}
+
+func (*TestSuite) TestDeviceStateWifiInfo_String(c *C) {
+	var str string
+
+	dswi := &DeviceStateWifiInfo{
+		Signal: 0.1234,
+		Tx:     1,
+		Rx:     2,
+	}
+
+	exp := fmt.Sprintf("<*lifxpayloads.DeviceStateWifiInfo(%p): Signal: 0.1234000027179718, Tx: 1, Rx: 2>", dswi)
+
+	str = dswi.String()
+	c.Check(str, Equals, exp)
 }
 
 func (t *TestSuite) TestDeviceStateWifiInfo_MarshalPacket(c *C) {
@@ -309,6 +371,22 @@ func (t *TestSuite) TestDeviceStateWifiInfo_UnmarshalPacket(c *C) {
 	c.Check(dswi.Reserved, Equals, int16(66))
 }
 
+func (*TestSuite) TestDeviceStateWifiFirmware_String(c *C) {
+	var str string
+
+	now := time.Now().UTC()
+
+	dswf := &DeviceStateWifiFirmware{
+		Build:   uint64(now.UnixNano()),
+		Version: 42,
+	}
+
+	exp := fmt.Sprintf("<*lifxpayloads.DeviceStateWifiFirmware(%p): Build: %s, Version: 42>", dswf, now.String())
+
+	str = dswf.String()
+	c.Check(str, Equals, exp)
+}
+
 func (t *TestSuite) TestDeviceStateWifiFirmware_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
@@ -356,6 +434,17 @@ func (t *TestSuite) TestDeviceStateWifiFirmware_UnmarshalPacket(c *C) {
 	c.Check(dswf.Version, Equals, uint32(99))
 }
 
+func (*TestSuite) TestDeviceStatePower_String(c *C) {
+	var str string
+
+	dsp := &DeviceStatePower{Level: 24}
+
+	exp := fmt.Sprintf("<*lifxpayloads.DeviceStatePower(%p): Level: 24>", dsp)
+
+	str = dsp.String()
+	c.Check(str, Equals, exp)
+}
+
 func (t *TestSuite) TestDeviceStatePower_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
@@ -384,6 +473,20 @@ func (t *TestSuite) TestDeviceStatePower_UnmarshalPacket(c *C) {
 
 	c.Assert(dsp.UnmarshalPacket(bytes.NewReader(buf.Bytes()), t.order), IsNil)
 	c.Check(dsp.Level, Equals, uint16(33))
+}
+
+func (*TestSuite) TestDeviceStateLabel_String(c *C) {
+	var str string
+
+	label, err := NewDeviceLabel([]byte("test label"))
+	c.Assert(err, IsNil)
+
+	dsl := &DeviceStateLabel{Label: label}
+
+	exp := fmt.Sprintf("<*lifxpayloads.DeviceStateLabel(%p): Label: \"test label\">", dsl)
+
+	str = dsl.String()
+	c.Check(str, Equals, exp)
 }
 
 func (t *TestSuite) TestDeviceStateLabel_MarshalPacket(c *C) {
@@ -432,6 +535,24 @@ func (t *TestSuite) TestDeviceStateLabel_UnmarshalPacket(c *C) {
 	}
 }
 
+func (*TestSuite) TestDeviceStateVersion_String(c *C) {
+	var str string
+
+	dsv := &DeviceStateVersion{
+		Vendor:  42,
+		Product: 1,
+		Version: 2,
+	}
+
+	exp := fmt.Sprintf(
+		"<*lifxpayloads.DeviceStateVersion(%p): Vendor: 42, Product: 1, Version: 2>",
+		dsv,
+	)
+
+	str = dsv.String()
+	c.Check(str, Equals, exp)
+}
+
 func (t *TestSuite) TestDeviceStateVersion_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
@@ -475,6 +596,26 @@ func (t *TestSuite) TestDeviceStateVersion_UnmarshalPacket(c *C) {
 	c.Check(dsv.Vendor, Equals, uint32(84))
 	c.Check(dsv.Product, Equals, uint32(10))
 	c.Check(dsv.Version, Equals, uint32(42))
+}
+
+func (*TestSuite) TestDeviceStateInfo_String(c *C) {
+	var str string
+
+	now := time.Now().UTC()
+
+	dsi := &DeviceStateInfo{
+		Time:     uint64(now.UnixNano()),
+		Uptime:   1,
+		Downtime: 2,
+	}
+
+	exp := fmt.Sprintf(
+		"<*lifxpayloads.DeviceStateInfo(%p): Time: %s, Uptime: 1, Downtime: 2>",
+		dsi, now,
+	)
+
+	str = dsi.String()
+	c.Check(str, Equals, exp)
 }
 
 func (t *TestSuite) TestDeviceStateInfo_MarshalPacket(c *C) {
@@ -522,6 +663,33 @@ func (t *TestSuite) TestDeviceStateInfo_UnmarshalPacket(c *C) {
 	c.Check(dsi.Downtime, Equals, uint64(42))
 }
 
+func (*TestSuite) TestDeviceStateLocation_String(c *C) {
+	var str string
+
+	locationStr := "location"
+	label := []byte("test.bulb")
+
+	var location [16]byte
+
+	for i, val := range locationStr {
+		location[i] = byte(val)
+	}
+
+	dsl := &DeviceStateLocation{
+		Location:  location,
+		Label:     NewDeviceLabelTrunc(label),
+		UpdatedAt: 42,
+	}
+
+	exp := fmt.Sprintf(
+		"<*lifxpayloads.DeviceStateLocation(%p): Location: \"location\", Label: \"test.bulb\", UpdatedAt: 42>",
+		dsl,
+	)
+
+	str = dsl.String()
+	c.Check(str, Equals, exp)
+}
+
 func (t *TestSuite) TestDeviceStateLocation_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
@@ -539,6 +707,7 @@ func (t *TestSuite) TestDeviceStateLocation_MarshalPacket(c *C) {
 	for i := 0; i < len(label); i++ {
 		label[i] = uint8(i + 100)
 	}
+
 	dsl := &DeviceStateLocation{
 		Location:  location,
 		Label:     NewDeviceLabelTrunc(label),
@@ -598,6 +767,33 @@ func (t *TestSuite) TestDeviceStateLocation_UnmarshalPacket(c *C) {
 	for i := 0; i < 32; i++ {
 		c.Check(dsl.Label[i], Equals, uint8(i+100))
 	}
+}
+
+func (*TestSuite) TestDeviceStateGroup_String(c *C) {
+	var str string
+
+	groupStr := "group"
+	label := []byte("test.bulb")
+
+	var group [16]byte
+
+	for i, val := range groupStr {
+		group[i] = byte(val)
+	}
+
+	dsg := &DeviceStateGroup{
+		Group:     group,
+		Label:     NewDeviceLabelTrunc(label),
+		UpdatedAt: 42,
+	}
+
+	exp := fmt.Sprintf(
+		"<*lifxpayloads.DeviceStateGroup(%p): Group: \"group\", Label: \"test.bulb\", UpdatedAt: 42>",
+		dsg,
+	)
+
+	str = dsg.String()
+	c.Check(str, Equals, exp)
 }
 
 func (t *TestSuite) TestDeviceStateGroup_MarshalPacket(c *C) {
@@ -676,6 +872,22 @@ func (t *TestSuite) TestDeviceStateGroup_UnmarshalPacket(c *C) {
 	for i := 0; i < 32; i++ {
 		c.Check(dsg.Label[i], Equals, uint8(i+100))
 	}
+}
+
+func (*TestSuite) TestDeviceEcho_String(c *C) {
+	var str string
+
+	payload := []byte("test echo payload")
+
+	de := &DeviceEcho{Payload: NewDeviceEchoPayloadTrunc(payload)}
+
+	exp := fmt.Sprintf(
+		"<*lifxpayloads.DeviceEcho(%p): Payload: \"test echo payload\">",
+		de,
+	)
+
+	str = de.String()
+	c.Check(str, Equals, exp)
 }
 
 func (t *TestSuite) TestDeviceEcho_MarshalPacket(c *C) {

--- a/protocol/payloads/lights.go
+++ b/protocol/payloads/lights.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"time"
 )
@@ -39,6 +40,24 @@ type LightHSBK struct {
 	// Kevin is the color temperature of the light. The lower the warmer
 	// (2500) the higher the cooler (9000).
 	Kelvin uint16
+}
+
+func (hsbk *LightHSBK) String() string {
+	if hsbk == nil {
+		return "<*lifxpayloads.LightHSBK(nil)>"
+	}
+
+	// scale hue value to 0-359
+	hue := colorRange(float64(hsbk.Hue))
+
+	// scale saturation and brightness values to 0-100
+	sat := percentageRange(float64(hsbk.Saturation))
+	bri := percentageRange(float64(hsbk.Brightness))
+
+	return fmt.Sprintf(
+		"<*lifxpayloads.LightHSBK(%p): Hue: %d (%d°), Saturation: %d (%d%%), Brightness: %d (%d%%), Kelvin: %d>",
+		hsbk, hsbk.Hue, hue, hsbk.Saturation, sat, hsbk.Brightness, bri, hsbk.Kelvin,
+	)
 }
 
 // MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
@@ -97,12 +116,23 @@ type LightSetColor struct {
 	Duration time.Duration
 }
 
-func durToMs(dur time.Duration) uint32 {
-	return uint32(dur / time.Millisecond)
-}
+func (lsc *LightSetColor) String() string {
+	if lsc == nil {
+		return "<*lifxpayloads.LightSetColor(nil)>"
+	}
 
-func msToDur(ms uint32) time.Duration {
-	return time.Duration(ms) * time.Millisecond
+	var color string
+
+	if lsc.Color != nil {
+		color = lsc.Color.String()
+	} else {
+		color = "<nil>"
+	}
+
+	return fmt.Sprintf(
+		"<*lifxpayloads.LightSetColor(%p): Color: %s, Duration: %s>",
+		lsc, color, lsc.Duration,
+	)
 }
 
 // MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
@@ -179,6 +209,35 @@ type LightState struct {
 	Label DeviceLabel
 
 	ReservedB uint64
+}
+
+func (ls *LightState) String() string {
+	if ls == nil {
+		return "<*lifxpayloads.LightState(nil)>"
+	}
+
+	var color string
+
+	if ls.Color != nil {
+		color = ls.Color.String()
+	} else {
+		color = "<nil>"
+	}
+
+	var power string
+
+	if ls.Power == 0 {
+		power = "OFF"
+	} else if ls.Power == 65535 {
+		power = "ON"
+	}
+
+	label := string(bytes.Trim(ls.Label[0:], "\x00"))
+
+	return fmt.Sprintf(
+		"<*lifxpayloads.LightState(%p): Color: %s, Power: %d (%s), Label: \"%s\">",
+		ls, color, ls.Power, power, label,
+	)
 }
 
 // MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
@@ -263,6 +322,25 @@ type LightSetPower struct {
 	Duration time.Duration
 }
 
+func (lsp *LightSetPower) String() string {
+	if lsp == nil { // LumpySpacePrincess
+		return "<*lifxpayloads.LightSetPower(nil)>"
+	}
+
+	var level string
+
+	if lsp.Level == 0 {
+		level = "OFF"
+	} else if lsp.Level == 65535 {
+		level = "ON"
+	}
+
+	return fmt.Sprintf(
+		"<*lifxpayloads.LightSetPower(%p): Level: %d (%s), Duration: %s>",
+		lsp, lsp.Level, level, lsp.Duration,
+	)
+}
+
 // MarshalPacket is a function that satisfies the lifxprotocol.Marshaler
 // interface.
 func (lsp *LightSetPower) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
@@ -306,6 +384,25 @@ func (lsp *LightSetPower) UnmarshalPacket(data io.Reader, order binary.ByteOrder
 // to provide the current power level.
 type LightStatePower struct {
 	Level uint16
+}
+
+func (lsp *LightStatePower) String() string {
+	if lsp == nil { // LumpySpacePrincess
+		return "<*lifxpayloads.LightStatePower(nil)>"
+	}
+
+	var level string
+
+	if lsp.Level == 0 {
+		level = "OFF"
+	} else if lsp.Level == 65535 {
+		level = "ON"
+	}
+
+	return fmt.Sprintf(
+		"<*lifxpayloads.LightStatePower(%p): Level: %d (%s)>",
+		lsp, lsp.Level, level,
+	)
 }
 
 // MarshalPacket is a function that satisfies the lifxprotocol.Marshaler

--- a/protocol/payloads/lights_test.go
+++ b/protocol/payloads/lights_test.go
@@ -3,10 +3,30 @@ package lifxpayloads
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"time"
 
 	. "gopkg.in/check.v1"
 )
+
+func (*TestSuite) TestLightHSBK_String(c *C) {
+	var str string
+
+	hsbk := &LightHSBK{
+		Hue:        65535,
+		Saturation: 32768,
+		Brightness: 16384,
+		Kelvin:     2900,
+	}
+
+	exp := fmt.Sprintf(
+		"<*lifxpayloads.LightHSBK(%p): Hue: 65535 (359°), Saturation: 32768 (50%%), Brightness: 16384 (25%%), Kelvin: 2900>",
+		hsbk,
+	)
+
+	str = hsbk.String()
+	c.Check(str, Equals, exp)
+}
 
 func (t *TestSuite) TestLightHSBK_MarshalPacket(c *C) {
 	var packet []byte
@@ -60,6 +80,30 @@ func (t *TestSuite) TestLightHSBK_UnmarshalPacket(c *C) {
 	c.Check(hsbk.Saturation, Equals, uint16(33))
 	c.Check(hsbk.Brightness, Equals, uint16(44))
 	c.Check(hsbk.Kelvin, Equals, uint16(55))
+}
+
+func (*TestSuite) TestLightSetColor_String(c *C) {
+	var str string
+
+	hsbk := &LightHSBK{
+		Hue:        65535,
+		Saturation: 32768,
+		Brightness: 16384,
+		Kelvin:     2900,
+	}
+
+	lsc := &LightSetColor{
+		Color:    hsbk,
+		Duration: 42 * time.Second,
+	}
+
+	exp := fmt.Sprintf(
+		"<*lifxpayloads.LightSetColor(%p): Color: %s, Duration: 42s>",
+		lsc, hsbk,
+	)
+
+	str = lsc.String()
+	c.Check(str, Equals, exp)
 }
 
 func (t *TestSuite) TestLightSetColor_MarshalPacket(c *C) {
@@ -141,6 +185,34 @@ func (t *TestSuite) TestLightSetColor_UnmarshalPacket(c *C) {
 	c.Check(lsc.Color.Brightness, Equals, uint16(44))
 	c.Check(lsc.Color.Kelvin, Equals, uint16(55))
 	c.Check(lsc.Duration, Equals, 66*time.Millisecond)
+}
+
+func (*TestSuite) TestLightState_String(c *C) {
+	var str string
+
+	label, err := NewDeviceLabel([]byte("test label"))
+	c.Assert(err, IsNil)
+
+	hsbk := &LightHSBK{
+		Hue:        65535,
+		Saturation: 32768,
+		Brightness: 16384,
+		Kelvin:     2900,
+	}
+
+	ls := &LightState{
+		Color: hsbk,
+		Power: 65535,
+		Label: label,
+	}
+
+	exp := fmt.Sprintf(
+		"<*lifxpayloads.LightState(%p): Color: %s, Power: 65535 (ON), Label: \"test label\">",
+		ls, hsbk,
+	)
+
+	str = ls.String()
+	c.Check(str, Equals, exp)
 }
 
 func (t *TestSuite) TestLightState_MarshalPacket(c *C) {
@@ -241,6 +313,23 @@ func (t *TestSuite) TestLightState_UnmarshalPacket(c *C) {
 	c.Check(ls.ReservedB, Equals, uint64(77))
 }
 
+func (*TestSuite) TestLightSetPower_String(c *C) {
+	var str string
+
+	lsp := &LightSetPower{
+		Level:    65535,
+		Duration: time.Second * 42,
+	}
+
+	exp := fmt.Sprintf(
+		"<*lifxpayloads.LightSetPower(%p): Level: 65535 (ON), Duration: 42s>",
+		lsp,
+	)
+
+	str = lsp.String()
+	c.Check(str, Equals, exp)
+}
+
 func (t *TestSuite) TestLightSetPower_MarshalPacket(c *C) {
 	var packet []byte
 	var err error
@@ -285,6 +374,20 @@ func (t *TestSuite) TestLightSetPower_UnmarshalPacket(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(lsp.Level, Equals, uint16(4))
 	c.Check(lsp.Duration, Equals, 22*time.Millisecond)
+}
+
+func (*TestSuite) TestLightStatePower_String(c *C) {
+	var str string
+
+	lsp := &LightStatePower{Level: 65535}
+
+	exp := fmt.Sprintf(
+		"<*lifxpayloads.LightStatePower(%p): Level: 65535 (ON)>",
+		lsp,
+	)
+
+	str = lsp.String()
+	c.Check(str, Equals, exp)
 }
 
 func (t *TestSuite) TestLightStatePower_MarshalPacket(c *C) {

--- a/protocol/payloads/util.go
+++ b/protocol/payloads/util.go
@@ -1,0 +1,59 @@
+package lifxpayloads
+
+import (
+	"math"
+	"time"
+)
+
+const (
+	maxUint16 float64 = 65535
+
+	colorRangeMax   float64 = 359
+	colorRangeMin   float64 = 0
+	hueRange                = maxUint16 - colorRangeMin
+	colorWheelRange         = colorRangeMax - colorRangeMin
+
+	percRangeMax    float64 = 100
+	percRangeMin    float64 = 0
+	percValueRange          = maxUint16 - percRangeMin
+	percScaledRange         = percRangeMax - percRangeMin
+)
+
+func colorRange(value float64) uint16 {
+	scaledValue := (((value - colorRangeMin) * colorWheelRange) / hueRange) + colorRangeMin
+	return uint16(scaledValue)
+}
+
+func percentageRange(value float64) uint8 {
+	scaledValue := (((value - percRangeMin) * percScaledRange) / percValueRange) + percRangeMin
+	return uint8(scaledValue)
+}
+
+// nsecEpochToTime converts a UNIX epoch with nanosecond
+// precision in to a time.Time where the Timezone is UTC.
+func nsecEpochToTime(nanoseconds uint64) time.Time {
+	nanoDur := time.Duration(nanoseconds)
+
+	// convert the value to the UNIX epoch
+	// with remaining nanoseconds (npoch)
+	epoch := int64(nanoDur / time.Second)
+	npoch := int64(nanoDur % time.Second)
+
+	return time.Unix(epoch, npoch).UTC()
+}
+
+func durToMs(dur time.Duration) uint32 {
+	return uint32(dur / time.Millisecond)
+}
+
+func msToDur(ms uint32) time.Duration {
+	return time.Duration(ms) * time.Millisecond
+}
+
+func round(f float64) float64 {
+	if f < 0 {
+		return math.Ceil(f - 0.5)
+	}
+
+	return math.Floor(f + 0.5)
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -43,6 +43,7 @@ type Unmarshaler interface {
 type PacketComponent interface {
 	Marshaler
 	Unmarshaler
+	fmt.Stringer
 }
 
 // Packet is the struct for an individual message whether inbound or
@@ -57,6 +58,31 @@ type Packet struct {
 	// based on what is being sent. The recipient knows how to parse this
 	// message based on the value of the Header.ProtocolHeader.Type field.
 	Payload PacketComponent
+}
+
+func (p *Packet) String() string {
+	if p == nil {
+		return "<*lifxprotocol.Packet(nil)>"
+	}
+
+	var hStr, pStr string
+
+	if p.Header == nil {
+		hStr = "<nil>"
+	} else {
+		hStr = p.Header.String()
+	}
+
+	if p.Payload == nil {
+		pStr = "<nil>"
+	} else {
+		pStr = p.Payload.String()
+	}
+
+	return fmt.Sprintf(
+		"<*lifxprotocol.Packet(%p): Header: %s, Payload: %s>",
+		p, hStr, pStr,
+	)
 }
 
 // MarshalPacket is a function that satisfies the Marshaler interface.

--- a/protocol/protocol_header.go
+++ b/protocol/protocol_header.go
@@ -7,6 +7,7 @@ package lifxprotocol
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 )
 
@@ -72,6 +73,17 @@ type ProtocolHeader struct {
 	ReservedEnd uint16
 }
 
+func (ph *ProtocolHeader) String() string {
+	if ph == nil {
+		return "<*lifxprotocol.ProtocolHeader(nil)>"
+	}
+
+	return fmt.Sprintf(
+		"<*lifxprotocol.ProtocolHeader(%p): Type: %d (%s)>",
+		ph, ph.Type, phTypetoString(ph.Type),
+	)
+}
+
 // MarshalPacket is a function that implements the Marshaler interface.
 func (ph *ProtocolHeader) MarshalPacket(order binary.ByteOrder) ([]byte, error) {
 	buf := &bytes.Buffer{}
@@ -116,4 +128,81 @@ func (ph *ProtocolHeader) UnmarshalPacket(data io.Reader, order binary.ByteOrder
 	}
 
 	return
+}
+
+func phTypetoString(t uint16) string {
+	var s string
+
+	switch t {
+	case DeviceGetService:
+		s = "DeviceGetService"
+	case DeviceStateService:
+		s = "DeviceStateService"
+	case DeviceGetHostInfo:
+		s = "DeviceGetHostInfo"
+	case DeviceStateHostInfo:
+		s = "DeviceStateHostInfo"
+	case DeviceGetHostFirmware:
+		s = "DeviceGetHostFirmware"
+	case DeviceStateHostFirmware:
+		s = "DeviceStateHostFirmware"
+	case DeviceGetWifiInfo:
+		s = "DeviceGetWifiInfo"
+	case DeviceStateWifiInfo:
+		s = "DeviceStateWifiInfo"
+	case DeviceGetWifiFirmware:
+		s = "DeviceGetWifiFirmware"
+	case DeviceStateWifiFirmware:
+		s = "DeviceStateWifiFirmware"
+	case DeviceGetPower:
+		s = "DeviceGetPower"
+	case DeviceSetPower:
+		s = "DeviceSetPower"
+	case DeviceStatePower:
+		s = "DeviceStatePower"
+	case DeviceGetLabel:
+		s = "DeviceGetLabel"
+	case DeviceSetLabel:
+		s = "DeviceSetLabel"
+	case DeviceStateLabel:
+		s = "DeviceStateLabel"
+	case DeviceGetVersion:
+		s = "DeviceGetVersion"
+	case DeviceStateVersion:
+		s = "DeviceStateVersion"
+	case DeviceGetInfo:
+		s = "DeviceGetInfo"
+	case DeviceStateInfo:
+		s = "DeviceStateInfo"
+	case DeviceAcknowledgement:
+		s = "DeviceAcknowledgement"
+	case DeviceGetLocation:
+		s = "DeviceGetLocation"
+	case DeviceStateLocation:
+		s = "DeviceStateLocation"
+	case DeviceGetGroup:
+		s = "DeviceGetGroup"
+	case DeviceStateGroup:
+		s = "DeviceStateGroup"
+	case DeviceEchoRequest:
+		s = "DeviceEchoRequest"
+	case DeviceEchoResponse:
+		s = "DeviceEchoResponse"
+	case LightGet:
+		s = "LightGet"
+	case LightSetColor:
+		s = "LightSetColor"
+	case LightState:
+		s = "LightState"
+	case LightGetPower:
+		s = "LightGetPower"
+	case LightSetPower:
+		s = "LightSetPower"
+	case LightStatePower:
+		s = "LightStatePower"
+	default:
+		return "UnknownType"
+	}
+
+	return "lifxprotocol." + s
 }

--- a/protocol/protocol_header_test.go
+++ b/protocol/protocol_header_test.go
@@ -7,9 +7,47 @@ package lifxprotocol
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 
 	. "gopkg.in/check.v1"
 )
+
+func (*TestSuite) Test_phTypeToString(c *C) {
+	c.Check(phTypetoString(DeviceGetService), Equals, "lifxprotocol.DeviceGetService")
+	c.Check(phTypetoString(DeviceStateService), Equals, "lifxprotocol.DeviceStateService")
+	c.Check(phTypetoString(DeviceGetHostInfo), Equals, "lifxprotocol.DeviceGetHostInfo")
+	c.Check(phTypetoString(DeviceStateHostInfo), Equals, "lifxprotocol.DeviceStateHostInfo")
+	c.Check(phTypetoString(DeviceGetHostFirmware), Equals, "lifxprotocol.DeviceGetHostFirmware")
+	c.Check(phTypetoString(DeviceStateHostFirmware), Equals, "lifxprotocol.DeviceStateHostFirmware")
+	c.Check(phTypetoString(DeviceGetWifiInfo), Equals, "lifxprotocol.DeviceGetWifiInfo")
+	c.Check(phTypetoString(DeviceStateWifiInfo), Equals, "lifxprotocol.DeviceStateWifiInfo")
+	c.Check(phTypetoString(DeviceGetWifiFirmware), Equals, "lifxprotocol.DeviceGetWifiFirmware")
+	c.Check(phTypetoString(DeviceStateWifiFirmware), Equals, "lifxprotocol.DeviceStateWifiFirmware")
+	c.Check(phTypetoString(DeviceGetPower), Equals, "lifxprotocol.DeviceGetPower")
+	c.Check(phTypetoString(DeviceSetPower), Equals, "lifxprotocol.DeviceSetPower")
+	c.Check(phTypetoString(DeviceStatePower), Equals, "lifxprotocol.DeviceStatePower")
+	c.Check(phTypetoString(DeviceGetLabel), Equals, "lifxprotocol.DeviceGetLabel")
+	c.Check(phTypetoString(DeviceSetLabel), Equals, "lifxprotocol.DeviceSetLabel")
+	c.Check(phTypetoString(DeviceStateLabel), Equals, "lifxprotocol.DeviceStateLabel")
+	c.Check(phTypetoString(DeviceGetVersion), Equals, "lifxprotocol.DeviceGetVersion")
+	c.Check(phTypetoString(DeviceStateVersion), Equals, "lifxprotocol.DeviceStateVersion")
+	c.Check(phTypetoString(DeviceGetInfo), Equals, "lifxprotocol.DeviceGetInfo")
+	c.Check(phTypetoString(DeviceStateInfo), Equals, "lifxprotocol.DeviceStateInfo")
+	c.Check(phTypetoString(DeviceAcknowledgement), Equals, "lifxprotocol.DeviceAcknowledgement")
+	c.Check(phTypetoString(DeviceGetLocation), Equals, "lifxprotocol.DeviceGetLocation")
+	c.Check(phTypetoString(DeviceStateLocation), Equals, "lifxprotocol.DeviceStateLocation")
+	c.Check(phTypetoString(DeviceGetGroup), Equals, "lifxprotocol.DeviceGetGroup")
+	c.Check(phTypetoString(DeviceStateGroup), Equals, "lifxprotocol.DeviceStateGroup")
+	c.Check(phTypetoString(DeviceEchoRequest), Equals, "lifxprotocol.DeviceEchoRequest")
+	c.Check(phTypetoString(DeviceEchoResponse), Equals, "lifxprotocol.DeviceEchoResponse")
+	c.Check(phTypetoString(LightGet), Equals, "lifxprotocol.LightGet")
+	c.Check(phTypetoString(LightSetColor), Equals, "lifxprotocol.LightSetColor")
+	c.Check(phTypetoString(LightState), Equals, "lifxprotocol.LightState")
+	c.Check(phTypetoString(LightGetPower), Equals, "lifxprotocol.LightGetPower")
+	c.Check(phTypetoString(LightSetPower), Equals, "lifxprotocol.LightSetPower")
+	c.Check(phTypetoString(LightStatePower), Equals, "lifxprotocol.LightStatePower")
+	c.Check(phTypetoString(^uint16(0)), Equals, "UnknownType")
+}
 
 func (t *TestSuite) TestProtocolHeaderDeviceTypes(c *C) {
 	c.Check(DeviceGetService, Equals, uint16(2))
@@ -48,6 +86,20 @@ func (t *TestSuite) TestProtocolHeaderLightTypes(c *C) {
 	c.Check(LightGetPower, Equals, uint16(116))
 	c.Check(LightSetPower, Equals, uint16(117))
 	c.Check(LightStatePower, Equals, uint16(118))
+}
+
+func (*TestSuite) TestProtocolHeader_String(c *C) {
+	var str string
+
+	ph := &ProtocolHeader{Type: 2}
+
+	exp := fmt.Sprintf(
+		"<*lifxprotocol.ProtocolHeader(%p): Type: 2 (lifxprotocol.DeviceGetService)>",
+		ph,
+	)
+
+	str = ph.String()
+	c.Check(str, Equals, exp)
 }
 
 func (t *TestSuite) TestProtocolHeader_MarshalPacket(c *C) {

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -50,6 +50,50 @@ func (t *TestSuite) SetUpSuite(c *C) {
 	t.source = uint32(rand.Int63n(int64(MaxUint32)))
 }
 
+func (*TestSuite) TestPacket_String(c *C) {
+	var str string
+
+	header := &Header{
+		Frame: &Frame{
+			Origin:      3,
+			Tagged:      true,
+			Addressable: true,
+			Protocol:    1024,
+			Source:      42,
+		},
+		FrameAddress: &FrameAddress{
+			Target:      []byte{1, 2, 3, 4, 5, 6},
+			AckRequired: true,
+			ResRequired: true,
+			Sequence:    128,
+		},
+		ProtocolHeader: &ProtocolHeader{Type: DeviceEchoResponse},
+	}
+
+	var pl [64]byte
+
+	for i, chr := range "test echo message" {
+		pl[i] = byte(chr)
+	}
+
+	payload := &lifxpayloads.DeviceEcho{
+		Payload: pl,
+	}
+
+	p := &Packet{
+		Header:  header,
+		Payload: payload,
+	}
+
+	exp := fmt.Sprintf(
+		"<*lifxprotocol.Packet(%p): Header: %s, Payload: %s>",
+		p, header, payload,
+	)
+
+	str = p.String()
+	c.Check(str, Equals, exp)
+}
+
 func (t *TestSuite) TestPacket_MarshalPacket(c *C) {
 	var packet []byte
 	var err error


### PR DESCRIPTION
To make it easier to understand the contents of each struct, I've added `fmt.Stringer` to the `lifxprotocol.PacketCompnent` interface. This allows us to print out each struct, and have a meaningful string representation of its contents. This is meant primarily for development and debugging purposes as well as logging (maybe?).
